### PR TITLE
会員登録後のリダイレクト先変更

### DIFF
--- a/src/app/Http/Controllers/ItemController.php
+++ b/src/app/Http/Controllers/ItemController.php
@@ -40,4 +40,9 @@ class ItemController extends Controller
 
         return view('detail', compact('item', 'category'));
     }
+
+    public function getProfile() {
+
+        return view('profile');
+    }
 }

--- a/src/app/Http/Controllers/RegisteredUserController.php
+++ b/src/app/Http/Controllers/RegisteredUserController.php
@@ -61,7 +61,7 @@ class RegisteredUserController extends Controller
 
         event(new Registered($user = $creator->create($request->all())));
 
-        $this->guard->login($user);
+        // $this->guard->login($user);
 
         return app(RegisterResponse::class);
     }

--- a/src/app/Http/Requests/LoginRequest.php
+++ b/src/app/Http/Requests/LoginRequest.php
@@ -25,7 +25,7 @@ class LoginRequest extends FortifyLoginRequest
     public function rules()
     {
         return [
-            'email'=>['required', 'email'],
+            'name'=>['required'],
             'password'=>['required', 'min:8'],
         ];
     }
@@ -33,8 +33,7 @@ class LoginRequest extends FortifyLoginRequest
     public function messages()
     {
         return [
-            'email.required'=>'メールアドレスを入力してください',
-            'email.email'=>'メールアドレスは「ユーザー名@ドメイン」形式で入力してください',
+            'name.required'=>'ユーザー名またはメールアドレスを入力してください',
             'password.required'=>'パスワードを入力してください',
             'password.min'=>'パスワードは8文字以上で入力してください',
         ];

--- a/src/app/Http/Responses/RegisterResponse.php
+++ b/src/app/Http/Responses/RegisterResponse.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Responses;
+
+use Illuminate\Http\JsonResponse;
+use Laravel\Fortify\Fortify;
+use Illuminate\Http\Response;
+use Laravel\Fortify\Contracts\RegisterResponse as RegisterResponseContract;
+
+class RegisterResponse implements RegisterResponseContract
+{
+    /**
+     * Create an HTTP response that represents the object.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function toResponse($request)
+    {
+        return $request->wantsJson()
+                    ? new JsonResponse('', 201)
+                    : redirect('/mypage/profile');
+    }
+}

--- a/src/app/Providers/FortifyServiceProvider.php
+++ b/src/app/Providers/FortifyServiceProvider.php
@@ -14,6 +14,10 @@ use Illuminate\Support\Str;
 use Laravel\Fortify\Fortify;
 use Laravel\Fortify\Http\Requests\LoginRequest as FortifyLoginRequest;
 use App\Http\Requests\LoginRequest;
+use Laravel\Fortify\Contracts\RegisterResponse as RegisterResponseContract;
+use App\Http\Responses\RegisterResponse;
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
 
 class FortifyServiceProvider extends ServiceProvider
 {
@@ -60,5 +64,20 @@ class FortifyServiceProvider extends ServiceProvider
         });
 
         $this->app->bind(FortifyLoginRequest::class, LoginRequest::class);
+
+        $this->app->singleton(
+            \Laravel\Fortify\Contracts\RegisterResponse::class,
+            \App\Http\Responses\RegisterResponse::class
+        );
+
+        Fortify::authenticateUsing(function (Request $request) {
+            $user = User::where('name', $request->name)->orWhere('email', $request->name)->first();
+
+            if ($user &&
+            Hash::check($request->password, $user->password)) {
+            return $user;
+        }
+        });
+
     }
 }

--- a/src/config/fortify.php
+++ b/src/config/fortify.php
@@ -46,7 +46,7 @@ return [
     |
     */
 
-    'username' => 'email',
+    'username' => 'name',
 
     'email' => 'email',
 

--- a/src/public/css/common.css
+++ b/src/public/css/common.css
@@ -76,6 +76,40 @@ a {
     border-radius: 3px;
 }
 
+/* ---user-img--- */
+.form-img {
+    display: flex;
+    align-items: center;
+    gap: 32px;
+}
+
+.user-img__wrap {
+    width: 100px;
+    height: 100px;
+    border-radius: 50%;
+    background-color: #d9d9d9;
+}
+
+.user-img__btn-wrap {
+    position: relative;
+}
+
+.user-img__select {
+    background-color: #fff;
+    color: #fd5152;
+    padding: 4px 12px;
+    border-radius: 5px;
+    border: 2px solid #fd5152;
+    font-size: 14px;
+    font-weight: bold;
+    cursor: pointer;
+    display: inline-block;
+}
+
+.user-img__hidden {
+    display: none;
+}
+
 @media screen and (max-width: 850px) {
     .header {
         grid-template-columns: 1fr 1fr;

--- a/src/resources/views/auth/login.blade.php
+++ b/src/resources/views/auth/login.blade.php
@@ -11,20 +11,18 @@
     <form class="form-group" action="/login" method="POST">
         @csrf
         <div class="form-group__item">
-            <label class="form-group__item-label">ユーザー名 / メールアドレス
-                <input class="form-group__item-input" type="text" name="email" value="{{ old('email') }}">
-            </label>
+            <p class="form-group__item-label">ユーザー名 / メールアドレス</p>
+            <input class="form-group__item-input" type="text" name=" name" value="{{ old('name') }}">
             <div class="error-message">
-                @error('email')
+                @error('name')
                 {{ $message }}
                 @enderror
             </div>
         </div>
 
         <div class="form-group__item">
-            <label class="form-group__item-label">パスワード
-                <input class="form-group__item-input" type="password" name="password">
-            </label>
+            <p class="form-group__item-label">パスワード</p>
+            <input class="form-group__item-input" type="password" name="password">
             <div class="error-message">
                 @error('password')
                 {{ $message }}

--- a/src/resources/views/profile.blade.php
+++ b/src/resources/views/profile.blade.php
@@ -7,9 +7,18 @@
 
 @section('content')
 <div class="form-container">
-    <h2 class="form-ttl">会員登録</h2>
-    <form class="form-group" action="/register" method="POST">
+    <h2 class="form-ttl">プロフィール設定</h2>
+    <form class="form-group" action="" method="POST">
         @csrf
+        <div class="form-group__item form-img">
+            <div class="user-img__wrap">
+                <img class="user-img" src="" alt="">
+            </div>
+            <div class="user-img__btn-wrap">
+                <label class="user-img__select" for="upload" >画像を選択する</label>
+                <input class="user-img__hidden" type="file" id="upload" accept="">
+            </div>
+        </div>
         <div class="form-group__item">
             <p class="form-group__item-label">ユーザー名</p>
             <input class="form-group__item-input" type="text" name="name" value="{{ old('name') }}">
@@ -21,41 +30,38 @@
         </div>
 
         <div class="form-group__item">
-            <p class="form-group__item-label">メールアドレス</p>
-            <input class="form-group__item-input" type="text" name="email" value="{{ old('email') }}">
+            <p class="form-group__item-label">郵便番号</p>
+            <input class="form-group__item-input" type="text" name="post_cord" value="{{ old('post_cord') }}">
             <div class="error-message">
-                @error('email')
+                @error('post_cord')
                 {{ $message }}
                 @enderror
             </div>
         </div>
 
         <div class="form-group__item">
-            <p class="form-group__item-label">パスワード</p>
-            <input class="form-group__item-input" type="password" name="password">
+            <p class="form-group__item-label">住所</p>
+            <input class="form-group__item-input" type="text" name="address">
             <div class="error-message">
-                @error('password')
+                @error('address')
                 {{ $message }}
                 @enderror
             </div>
         </div>
 
         <div class="form-group__item">
-            <p class="form-group__item-label">確認用パスワード</p>
-            <input class="form-group__item-input" type="password" name="password_confirmation">
+            <p class="form-group__item-label">建物名</p>
+            <input class="form-group__item-input" type="text" name="building">
             <div class="error-message">
-                @error('password_confirmation')
+                @error('building')
                 {{ $message }}
                 @enderror
             </div>
         </div>
 
         <button class="form-btn btn-margin" type="submit">
-            登録する
+            更新する
         </button>
     </form>
-    <a class="guid-text" href="/login">
-        ログインはこちらから
-    </a>
 </div>
 @endsection

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -24,3 +24,7 @@ Route::post('/register', [RegisteredUserController::class, 'store']);
 Route::get('/', [ItemController::class, 'index']);
 Route::get('/search', [ItemController::class, 'searchItem']);
 Route::get('/item/:{item_id}', [ItemController::class, 'getDetail']);
+
+Route::middleware('auth')->group(function () {
+    Route::get('/mypage/profile', [ItemController::class, 'getProfile']);
+});


### PR DESCRIPTION
RegisterResponse.phpを作成し、会員登録後のリダイレクト先をプロフィール設定画面に設定（ルートにauthミドルウェアを設定しているため、会員登録→ログイン画面→プロフィール設定画面の順に移遷する）

ユーザー名またはメールアドレスでログインできるよう設定

共通cssをcommon.cssに記述