### PR TITLE
初回ログイン時のプロフィール設定

### DIFF
--- a/src/app/Http/Controllers/ItemController.php
+++ b/src/app/Http/Controllers/ItemController.php
@@ -57,6 +57,13 @@ class ItemController extends Controller
     }
 
     public function postComment(CommentRequest $request, $item_id) {
+
+        $user = Auth::user();
+
+        if (!$user->profile_completed) {
+            return redirect('/mypage/profile')->with('error', 'コメントするにはプロフィールを設定してください');
+        }
+
         Comment::create([
         'user_id' => Auth::id(),
         'item_id' => $item_id,

--- a/src/app/Http/Controllers/UserController.php
+++ b/src/app/Http/Controllers/UserController.php
@@ -34,6 +34,7 @@ class UserController extends Controller
             'address' => $request->address,
             'building' => $request->building,
             'image_url' => $image_url,
+            'profile_completed' => true,
             ]);
         }else {
             User::find(Auth::id())->update([
@@ -41,10 +42,11 @@ class UserController extends Controller
             'post_cord' => $request->post_cord,
             'address' => $request->address,
             'building' => $request->building,
+            'profile_completed' => true,
             ]);
         }
 
-        return redirect('/mypage')->with('result', 'プロフィールを更新しました');
+        return redirect('/mypage')->with('result', 'プロフィールが更新されました');
     }
 
     public function getMypage(Request $request) {

--- a/src/app/Http/Responses/LoginResponse.php
+++ b/src/app/Http/Responses/LoginResponse.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Responses;
+
+use Illuminate\Http\JsonResponse;
+use Laravel\Fortify\Fortify;
+use Laravel\Fortify\Contracts\LoginResponse as LoginResponseContract;
+use Illuminate\Support\Facades\Auth;
+
+class LoginResponse implements LoginResponseContract
+{
+    /**
+     * Create an HTTP response that represents the object.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function toResponse($request)
+    {
+        $user = Auth::user();
+
+        if (!$user->profile_completed) {
+            return redirect('/mypage/profile');
+        }
+
+        return $request->wantsJson()
+            ? new JsonResponse(['two_factor' => false], 200)
+            : redirect()->intended(config('fortify.home'));
+    }
+}

--- a/src/app/Http/Responses/RegisterResponse.php
+++ b/src/app/Http/Responses/RegisterResponse.php
@@ -18,7 +18,7 @@ class RegisterResponse implements RegisterResponseContract
     public function toResponse($request)
     {
         return $request->wantsJson()
-                    ? new JsonResponse('', 201)
-                    : redirect('/mypage/profile');
+            ? new JsonResponse(['message' => 'Registration successful'], 201)
+            : redirect()->route('login')->with('result', '会員登録が完了しました。ログインしてください');
     }
 }

--- a/src/app/Models/User.php
+++ b/src/app/Models/User.php
@@ -27,6 +27,7 @@ class User extends Authenticatable implements MustVerifyEmail
         'address',
         'building',
         'image_url',
+        'profile_completed'
     ];
 
     /**
@@ -46,6 +47,7 @@ class User extends Authenticatable implements MustVerifyEmail
      */
     protected $casts = [
         'email_verified_at' => 'datetime',
+        'profile_completed' => 'boolean',
     ];
 
     public static function getPaymentUser()

--- a/src/app/Providers/FortifyServiceProvider.php
+++ b/src/app/Providers/FortifyServiceProvider.php
@@ -16,6 +16,8 @@ use Laravel\Fortify\Http\Requests\LoginRequest as FortifyLoginRequest;
 use App\Http\Requests\LoginRequest;
 use Laravel\Fortify\Contracts\RegisterResponse as RegisterResponseContract;
 use App\Http\Responses\RegisterResponse;
+use App\Http\Responses\LoginResponse;
+use Laravel\Fortify\Contracts\LoginResponse as LoginResponseContract;
 use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 
@@ -73,6 +75,8 @@ class FortifyServiceProvider extends ServiceProvider
             \Laravel\Fortify\Contracts\RegisterResponse::class,
             \App\Http\Responses\RegisterResponse::class
         );
+
+        $this->app->singleton(LoginResponseContract::class, LoginResponse::class);
 
         Fortify::authenticateUsing(function (Request $request) {
             $user = User::where('name', $request->name)->orWhere('email', $request->name)->first();

--- a/src/database/factories/UserFactory.php
+++ b/src/database/factories/UserFactory.php
@@ -24,6 +24,7 @@ class UserFactory extends Factory
             'address' => mb_substr($this->faker->address(), 9),
             'building' => $this->faker->secondaryAddress(),
             'image_url' => 'https://picsum.photos/seed/picsum/200/300',
+            'profile_completed' => true,
             'remember_token' => Str::random(10),
         ];
     }

--- a/src/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/src/database/migrations/2014_10_12_000000_create_users_table.php
@@ -24,6 +24,7 @@ class CreateUsersTable extends Migration
             $table->string('address')->nullable();
             $table->string('building')->nullable();
             $table->text('image_url')->nullable();
+            $table->boolean('profile_completed')->default(false);
             $table->rememberToken();
             $table->timestamps();
         });

--- a/src/public/css/detail.css
+++ b/src/public/css/detail.css
@@ -106,19 +106,27 @@
     width: 100%;
     max-height: 300px;
     overflow-y: scroll;
+    scrollbar-width: thin;
+    scrollbar-color: #888 #f1f1f1;
 }
 
 .item-comment__inner::-webkit-scrollbar {
     width: 4px;
-    height: 4px;
 }
 
 .item-comment__inner::-webkit-scrollbar-track {
-    background: #fff;
+    background: #f1f1f1;
+    border-radius: 4px;
 }
 
 .item-comment__inner::-webkit-scrollbar-thumb {
-    background: #fff;
+    background: #888;
+    border-radius: 4px;
+    -webkit-appearance: none;
+}
+
+.item-comment__inner::-webkit-scrollbar-thumb:hover {
+    background: #555;
 }
 
 .item-comment__wrap:not(:first-of-type) {
@@ -186,11 +194,11 @@
 }
 
 @keyframes fadeIn {
-    0% {
+    from {
         opacity: 0;
     }
 
-    100% {
+    to {
         opacity: 1;
     }
 }

--- a/src/public/js/app.js
+++ b/src/public/js/app.js
@@ -1,0 +1,7 @@
+document.addEventListener("DOMContentLoaded", function() {
+    setTimeout(() => {
+        document.querySelectorAll('.flash_success-message, .flash_error-message').forEach(el => {
+            el.style.display = 'none';
+        });
+    }, 5000);
+});

--- a/src/resources/views/auth/login.blade.php
+++ b/src/resources/views/auth/login.blade.php
@@ -6,6 +6,11 @@
 @endsection
 
 @section('content')
+@if (session('result'))
+    <div class="flash_success-message">
+        {{ session('result') }}
+    </div>
+@endif
 @if (session('error'))
     <div class="flash_error-message">
         {{ session('error') }}

--- a/src/resources/views/layouts/app.blade.php
+++ b/src/resources/views/layouts/app.blade.php
@@ -63,6 +63,6 @@
     <main class="main">
         @yield('content')
     </main>
-
+<script src="{{ asset('js/app.js') }}"></script>
 </body>
 </html>

--- a/src/resources/views/profile.blade.php
+++ b/src/resources/views/profile.blade.php
@@ -6,6 +6,12 @@
 @endsection
 
 @section('content')
+@if (session('error'))
+    <div class="flash_error-message">
+        {{ session('error') }}
+    </div>
+@endif
+
 <div class="form-container">
     <h2 class="form-header">プロフィール設定</h2>
     <form class="form-group" action="/mypage/profile" method="POST" enctype="multipart/form-data">


### PR DESCRIPTION
会員登録後の画面遷移設定を修正（プロフィール画面→ログイン画面）&セッションメッセージ追加
usersテーブルにprofile_completedカラムを追加し、プロフィール設定が完了した場合にtrueになるように設定
ログイン時にプロフィールを設定していない場合はプロフィール設定画面に移遷される

セッションメッセージを5秒後に自動で消えるようにした（app.js）
商品詳細画面のコメント表示のスクロールバーを修正