### PR TITLE
二重登録対策

### DIFF
--- a/src/app/Http/Controllers/StripeWebhookController.php
+++ b/src/app/Http/Controllers/StripeWebhookController.php
@@ -4,11 +4,13 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use App\Models\Purchase;
 use App\Models\Item;
 use Stripe\Webhook;
 use Stripe\Stripe;
+use Stripe\Checkout\Session;
 use Stripe\Exception\SignatureVerificationException;
 use Illuminate\Support\Facades\Mail;
 use App\Mail\KonbiniPaymentMail;
@@ -21,6 +23,7 @@ use App\Mail\KonbiniPaymentFailureMail;
 use App\Mail\SellerNotificationMail;
 use App\Mail\ShippingNotificationMail;
 use App\Mail\SellerOrderCancelMail;
+use App\Mail\PurchaseFailedMail;
 
 class StripeWebhookController extends Controller
 {
@@ -52,7 +55,7 @@ class StripeWebhookController extends Controller
 
         Mail::to($session->customer_details->email)->send(new OrderConfirmationMail($data));
 
-        Log::info("📩 注文確認メールを送信しました: ", $data);
+        Log::info("📩 購入者へ注文確認メールを送信しました: ", $data);
     }
 
     // 出品者へ商品が売れた連絡
@@ -84,7 +87,7 @@ class StripeWebhookController extends Controller
             'voucher_url' => $hostedVoucherUrl,
             'expires_at' => $expiresAt,
         ];
-        Log::info('📩 送信するメールデータ:', $data);
+        Log::info('📩 購入者へ支払い手順メールを送信しました:', $data);
 
         Mail::to($session->customer_details->email)->send(new KonbiniPaymentMail($data));
     }
@@ -137,59 +140,102 @@ class StripeWebhookController extends Controller
 
             // カード決済完了 & コンビニ支払い手順メール送信
             if ($event->type === 'checkout.session.completed') {
-                // payment_intentを取得
-                if (!empty($session->payment_intent)) {
-                    $paymentIntent = PaymentIntent::retrieve($session->payment_intent);
-                    // 支払い方法を取得
-                    $paymentMethodType = $paymentIntent->payment_method_types[0] ?? null;
+                DB::beginTransaction();
+                try {
+                    // payment_intentを取得
+                    $paymentMethodType = null;
+                    if (!empty($session->payment_intent)) {
+                        try {
+                            $paymentIntent = PaymentIntent::retrieve($session->payment_intent);
+                            $paymentMethodType = $paymentIntent->payment_method_types[0] ?? null;
+                            Log::info("📌 使用された支払い方法: " . $paymentMethodType);
+                        } catch (\Exception $e) {
+                            Log::error("❌ PaymentIntent の取得に失敗しました: " . $e->getMessage());
+                        }
+                    }
 
-                    Log::info("📌 使用された支払い方法: " . $paymentMethodType);
-                }
-                // データベースに保存
-                Purchase::create([
-                    'user_id' => $session['metadata']['user_id'],
-                    'item_id' => $session['metadata']['item_id'],
-                    'payment_id' => ($paymentMethodType == 'card' ? 2 : 1),
-                    'post_cord' => $session['metadata']['post_cord'],
-                    'address' => $session['metadata']['address'],
-                    'building' => $session['metadata']['building'],
-                    'stripe_session_id' => $session['id'],
-                    'payment_status' => ($paymentMethodType == 'card' ? 'paid' : 'pending'),
-                ]);
+                    $metadata = $session->metadata ?? [];
+                    $userId = $metadata['user_id'] ?? null;
+                    $itemId = $metadata['item_id'] ?? null;
+                    $postCord = $metadata['post_cord'] ?? '';
+                    $address = $metadata['address'] ?? '';
+                    $building = $metadata['building'] ?? '';
 
-                Item::find($session['metadata']['item_id'])->update([
-                    'status' => 2,
-                ]);
+                    // `status=1` の場合のみ `status=2` に更新（アトミックロック）
+                    // update の際に status = 1（未購入）を status = 2（購入済み）に 「同時に」変更できた場合のみ成功 させる
+                    $updated = Item::where('id', $itemId)
+                        ->where('status', 1) // 未購入状態を確認
+                        ->update(['status' => 2]);
+                        Log::info('✅ 商品のステータスを購入済みに更新しました', ['item_id' => $itemId, 'session_id' => $session->id]);
+                    
+                    // 他のユーザーが先に購入していた場合（更新なし)
+                    if ($updated === 0) {
+                        Log::warning("❌ 商品が既に購入済みです", ['item_id' => $itemId]);
 
-                $this->orderConfirmationMail($session, $paymentMethodType);
+                        DB::rollBack();
+                        Session::update($session->id, [
+                            'metadata' => ['purchase_error' => 'already_sold']
+                        ]);
 
-                $this->sellerNotificationMail($session, $paymentMethodType);
+                        // 購入者へ「商品が購入済み」の通知メールを送信
+                        $data = [
+                            'purchaser_nickname' => $metadata['purchaser_nickname'] ?? 'お客',
+                            'item_name' => $metadata['item_name'] ?? '商品',
+                        ];
+                        Mail::to($session->customer_details->email)->send(new PurchaseFailedMail($data));
 
-                // コンビニ決済処理
-                if($paymentMethodType == 'konbini') {
-                    $this->konbiniPaymentMail($session, $paymentIntent);
-                }
+                        Log::info("📩 購入失敗メールを送信しました: ", ['email' => $session->customer_details->email, 'data' => $data]);
 
-                // カード決済完了時
-                if($paymentMethodType == 'card') {
-                    $this->shippingNotificationMail($session, $paymentMethodType);
+                        return;
+                    }
+
+                    Purchase::create([
+                        'user_id' => $userId,
+                        'item_id' => $itemId,
+                        'payment_id' => ($paymentMethodType == 'card' ? 2 : 1),
+                        'post_cord' => $postCord,
+                        'address' => $address,
+                        'building' => $building,
+                        'stripe_session_id' => $session['id'],
+                        'payment_status' => ($paymentMethodType == 'card' ? 'paid' : 'pending'),
+                    ]);
+
+                    DB::commit();
+                    Log::info("✅ 商品購入完了", ['item_id' => $itemId, 'user_id' => $userId]);
+
+                    $this->orderConfirmationMail($session, $paymentMethodType);
+
+                    $this->sellerNotificationMail($session, $paymentMethodType);
+
+                    // コンビニ決済処理
+                    if($paymentMethodType == 'konbini') {
+                        $this->konbiniPaymentMail($session, $paymentIntent);
+                    }
+
+                    // カード決済完了時
+                    if($paymentMethodType == 'card') {
+                        $this->shippingNotificationMail($session, $paymentMethodType);
+                    }
+
+                } catch (\Exception $e) {
+                    Log::error("❌ checkout.session.completed の処理中にエラーが発生しました: " . $e->getMessage());
                 }
             }
 
             // コンビニ決済完了時の処理
             if ($event->type === 'checkout.session.async_payment_succeeded') {
-                $updated = Purchase::where('stripe_session_id', $session['id'])->update([
-                    'payment_status' => 'paid'
-                ]);
-
-                // コンビニ決済完了メール
-                $this->konbiniPaymentSuccessMail($session);
-
-                // 発送準備メール
-                $this->shippingNotificationMail($session, $paymentMethodType);
+                $updated = Purchase::where('stripe_session_id', $session['id'])->first();
 
                 if ($updated) {
                     Log::info("✅ コンビニ支払い完了: ", ['session_id' => $session->id]);
+                    $updated->update([
+                        'payment_status' => 'paid'
+                    ]);
+                    Log::info('✅ 購入ステータスをpaidに更新しました', ['session_id' => $session->id]);
+                    // コンビニ決済完了メール
+                    $this->konbiniPaymentSuccessMail($session);
+                    // 発送準備メール
+                    $this->shippingNotificationMail($session, $paymentMethodType);
                 } else {
                     Log::error("❌ 購入データが見つかりませんでした。Session ID: " . $session->id);
                 }
@@ -199,9 +245,13 @@ class StripeWebhookController extends Controller
             if ($event->type === 'checkout.session.async_payment_failed') {
                 $expiresAt = Carbon::createFromTimestamp($session->expires_at);
 
-                Log::error("❌ 非同期決済が失敗しました: ", ['session_id' => $sessionId]);
-
                 $purchase = Purchase::with('user')->where('stripe_session_id', $sessionId)->first();
+
+                // テスト(実際にデータベースに登録してあるデータを使用)
+                // $purchase = Purchase::where('stripe_session_id', 'cs_test_a1x01UVYipPNmJ8QJ0RtMdrSGjfqgd1qTIobHNQYKnlbi9E7wCLBKCpeIx')->with('user')->first();
+                // テストここまで
+
+                Log::error("❌ 非同期決済が失敗しました: ", ['session_id' => $sessionId]);
 
                 if ($purchase) {
                     $purchase->update([
@@ -212,34 +262,33 @@ class StripeWebhookController extends Controller
                         $item->update([
                             'status' => 1,
                         ]);
-                        Log::info('✅ 商品のステータスを更新しました', ['item_id' => $purchase->item_id]);
+                        Log::info('✅ 商品のステータスを出品に更新しました', ['item_id' => $purchase->item_id, 'purchase' => $purchase]);
+
+                        // 購入者への決済失敗メール
+                        $data = [
+                            'purchaser_nickname' => $purchase->user->nickname ?? 'お客',
+                            'item' => $item->name ?? '商品',
+                            'price' => $session->amount_total,
+                            'expires_at' => $expiresAt,
+                        ];
+
+                        Mail::to($session->customer_details->email)->send(new KonbiniPaymentFailureMail($data));
+
+                        Log::info("✅ 購入者へコンビニ決済失敗メールを送信しました: ", ['data' => $data]);
+
+                        // 出品者へのキャンセルメール
+                        $data = [
+                            'seller_nickname' => $item->user->nickname ?? 'お客',
+                            'item' => $item->name ?? '商品',
+                            'price' => $session->amount_total,
+                        ];
+
+                        Mail::to($item->user->email)->send(new SellerOrderCancelMail($data));
+                        Log::info("📩 出品者へキャンセルメールを送信しました: ", $data);
                     }
 
                     Log::info("❌ 注文をキャンセルしました: ", ['session_id' => $sessionId]);
                 }
-
-                // 購入者への決済失敗メール
-                $data = [
-                    'purchaser_nickname' => $purchase->user->nickname ?? 'お客',
-                    'item' => $item->name ?? '商品',
-                    'price' => $session->amount_total,
-                    'expires_at' => $expiresAt,
-                ];
-                Log::error("✅ 決済失敗メールデータ: ", ['data' => $data]);
-
-                Mail::to($session->customer_details->email)->send(new KonbiniPaymentFailureMail($data));
-                Log::info("📩 コンビニ決済失敗メールを送信しました: ", $data);
-
-                // 出品者へのキャンセルメール
-                $data = [
-                    'seller_nickname' => $item->user->nickname ?? 'お客',
-                    'item' => $item->name ?? '商品',
-                    'price' => $session->amount_total,
-                ];
-                Log::error("✅ キャンセルメールデータ: ", ['data' => $data]);
-
-                Mail::to($item->user->email)->send(new SellerOrderCancelMail($data));
-                Log::info("📩 出品者へキャンセルメールを送信しました: ", $data);
             }
 
             // 決済が失敗した場合

--- a/src/app/Http/Controllers/UserController.php
+++ b/src/app/Http/Controllers/UserController.php
@@ -54,10 +54,10 @@ class UserController extends Controller
 
         switch ($request['tab']) {
             case 'sell':
-                $items = Item::getSellItems();
+                $items = Item::getExhibitedItems();
                 break;
             case 'buy':
-                $items = Item::getBuyItems();
+                $items = Item::getPurchasedItems();
                 break;
             default:
                 $items = [];
@@ -75,6 +75,12 @@ class UserController extends Controller
     }
 
     public function postSell(ExhibitionRequest $request) {
+        $user = Auth::user();
+
+        if (!$user->profile_completed) {
+            return redirect('/mypage/profile')->with('error', '商品を出品するにはプロフィールを設定してください');
+        }
+
         $image_url = Item::getImageUrl($request->file('image_url'));
 
         Item::create([

--- a/src/app/Mail/PurchaseFailedMail.php
+++ b/src/app/Mail/PurchaseFailedMail.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class PurchaseFailedMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public $data;
+
+    /**
+     * Create a new message instance.
+     *
+     * @return void
+     */
+    public function __construct($data)
+    {
+        $this->data = $data;
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        return $this->subject('【重要】ご希望の商品が売り切れました')->view('emails.purchase_failed')
+        ->with('data', $this->data);
+    }
+}

--- a/src/database/factories/UserFactory.php
+++ b/src/database/factories/UserFactory.php
@@ -14,6 +14,10 @@ class UserFactory extends Factory
      */
     public function definition()
     {
+        $streetAddress = $this->faker->streetAddress;
+        $city = $this->faker->city;
+        $prefecture = $this->faker->prefecture;
+
         return [
             'name' => $this->faker->name(),
             'email' => $this->faker->unique()->safeEmail(),
@@ -21,7 +25,7 @@ class UserFactory extends Factory
             'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
             'nickname' => $this->faker->userName(),
             'post_cord' => substr_replace($this->faker->postcode(), '-', 3, 0),
-            'address' => mb_substr($this->faker->address(), 9),
+            'address' => $prefecture.$city.$streetAddress,
             'building' => $this->faker->secondaryAddress(),
             'image_url' => 'https://picsum.photos/seed/picsum/200/300',
             'profile_completed' => true,

--- a/src/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/src/database/migrations/2014_10_12_000000_create_users_table.php
@@ -16,7 +16,7 @@ class CreateUsersTable extends Migration
         Schema::create('users', function (Blueprint $table) {
             $table->id();
             $table->string('name');
-            $table->string('email');
+            $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
             $table->string('nickname')->nullable();

--- a/src/public/css/purchase.css
+++ b/src/public/css/purchase.css
@@ -97,12 +97,9 @@
     text-align: center;
 }
 
-.purchase-confirm__table-item--span {
+.purchase-confirm__table-item--span,
+.purchase-confirm__table-item {
     font-size: 18px;
-}
-
-.purchase-confirm__table-item:first-of-type {
-    font-size: 20px;
 }
 
 .purchase-btn {

--- a/src/public/js/app.js
+++ b/src/public/js/app.js
@@ -1,18 +1,22 @@
 document.addEventListener("DOMContentLoaded", function () {
-    // setTimeout(() => {
-    //     document.querySelectorAll('.flash_success-message, .flash_error-message').forEach(el => {
-    //         el.style.display = 'none';
-    //     });
-    // }, 5000);
+    document.querySelectorAll('.form-group, .item-comment__form, .purchase-form, sell-form').forEach(form => {
+        const button = form.querySelector('.form-btn');
+
+        form.addEventListener("submit", function () {
+            button.disabled = true;
+            button.textContent = "登録中...";
+        });
+    });
+
 
     setTimeout(() => {
         document.querySelectorAll('.flash_success-message, .flash_error-message').forEach(el => {
             el.style.transition = 'opacity 0.5s ease-out, transform 0.5s ease-out';
             el.style.opacity = '0';
-            el.style.transform = 'translateY(-20px)'; // 上にスライドさせながら消す
+            el.style.transform = 'translateY(-20px)';
             setTimeout(() => {
                 el.style.display = 'none';
-            }, 500); // フェードアウト完了後に非表示
+            }, 500);
         });
     }, 5000);
 });

--- a/src/resources/views/emails/konbini_payment.blade.php
+++ b/src/resources/views/emails/konbini_payment.blade.php
@@ -26,7 +26,7 @@
         font-weight: bold;
         text-align: center;
         padding-bottom: 10px;
-        border-bottom: 2px solid #e24a4a;
+        border-bottom: 2px solid rgb(59, 194, 52);
     }
     .content {
         margin-top: 20px;

--- a/src/resources/views/emails/order_confirmation.blade.php
+++ b/src/resources/views/emails/order_confirmation.blade.php
@@ -25,7 +25,7 @@
         font-weight: bold;
         text-align: center;
         padding-bottom: 10px;
-        border-bottom: 2px solid #e24a4a;
+        border-bottom: 2px solid rgb(59, 194, 52);
     }
     .content {
         margin-top: 20px;

--- a/src/resources/views/emails/purchase_failed.blade.php
+++ b/src/resources/views/emails/purchase_failed.blade.php
@@ -3,9 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>coachtechフリマアプリ コンビニ決済完了メール</title>
+    <title>coachtechフリマアプリ ご希望商品が売り切れました</title>
 </head>
-
 <style>
     body {
         font-family: 'Arial', sans-serif;
@@ -26,7 +25,7 @@
         font-weight: bold;
         text-align: center;
         padding-bottom: 10px;
-        border-bottom: 2px solid rgb(59, 194, 52);
+        border-bottom: 2px solid #e24a4a;
     }
     .content {
         margin-top: 20px;
@@ -37,21 +36,15 @@
 
 <body>
     <div class="container">
-        <div class="header">コンビニ決済完了のご連絡</div>
+        <div class="header">ご希望商品が売り切れました</div>
         <div class="content">
             <p>本メールはサーバーからの自動配信メールです。</p>
             <br>
             <p>{{ $data['purchaser_nickname'] }}様</p>
             <p>この度は、coachtechフリマアプリをご利用いただき誠にありがとうございます。</p>
-            <p>以下の注文のコンビニ支払いが完了しましたので、ご連絡します。</p>
+            <p>ご希望の商品「<strong>{{ $data['item_name'] }}</strong>」は、すでに他の方が購入されたため、購入できませんでした。</p>
+
             <br>
-            <p>■ 注文内容</p>
-            <ul>
-                <li>商品名&nbsp;:&nbsp; {{ $data['item'] }}</li>
-                <li>価格&nbsp;:&nbsp; <span>¥</span>{{number_format($data['price'])}}</li>
-            </ul>
-            <br>
-            <p>出品者様より商品が発送されるまで、今しばらくお待ちください。</p>
             <p>またのご利用をお待ちしております。</p>
         </div>
     </div>

--- a/src/resources/views/emails/seller_notification.blade.php
+++ b/src/resources/views/emails/seller_notification.blade.php
@@ -26,7 +26,7 @@
         font-weight: bold;
         text-align: center;
         padding-bottom: 10px;
-        border-bottom: 2px solid #e24a4a;
+        border-bottom: 2px solid rgb(59, 194, 52);
     }
     .content {
         margin-top: 20px;

--- a/src/resources/views/emails/shipping_notification.blade.php
+++ b/src/resources/views/emails/shipping_notification.blade.php
@@ -26,7 +26,7 @@
         font-weight: bold;
         text-align: center;
         padding-bottom: 10px;
-        border-bottom: 2px solid #e24a4a;
+        border-bottom: 2px solid rgb(59, 194, 52);
     }
     .content {
         margin-top: 20px;

--- a/src/resources/views/layouts/app.blade.php
+++ b/src/resources/views/layouts/app.blade.php
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>coachtechフリマ</title>
-    <link rel="stylesheet" href="https://unpkg.com/ress/dist/ress.min.css" />
+    <link rel="stylesheet" href="https://unpkg.com/ress@5.0.2/dist/ress.min.css">
     <link rel="stylesheet" href="{{ asset('css/common.css')}}">
     @yield('css')
 </head>

--- a/src/resources/views/purchase.blade.php
+++ b/src/resources/views/purchase.blade.php
@@ -40,7 +40,7 @@
                         @endforeach
                     </select>
                     <div class="error-message">
-                        @error('way')
+                        @error('payment_id')
                         {{ $message }}
                         @enderror
                     </div>

--- a/src/resources/views/stripe/success.blade.php
+++ b/src/resources/views/stripe/success.blade.php
@@ -12,4 +12,21 @@
     <p class="result-message">お支払いありがとうございました。</p>
     <a class="home-btn" href="/mypage">マイページに戻る</a>
 </div>
+
+<script>
+document.addEventListener("DOMContentLoaded", async function () {
+    const urlParams = new URLSearchParams(window.location.search);
+    const sessionId = urlParams.get("session_id");
+
+    if (sessionId) {
+        const response = await fetch(`/stripe/session-status?session_id=${sessionId}`);
+        const data = await response.json();
+
+        if (data.purchase_error === "already_sold") {
+            alert("申し訳ありません。この商品は既に購入されています。");
+            window.location.href = `/item/${data.item_id}`;
+        }
+    }
+});
+</script>
 @endsection

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -39,7 +39,7 @@ Route::middleware('auth', 'verified')->group(function () {
 
     Route::get('/purchase/{item_id}', [PurchaseController::class, 'getPurchase']);
     Route::post('/purchase/{item_id}', [PurchaseController::class, 'postPurchase'])->name('stripe.session');
-    
+
     Route::get('/purchase/address/{item_id}', [PurchaseController::class, 'getAddress']);
     Route::post('/purchase/address/{item_id}', [PurchaseController::class, 'postAddress']);
 
@@ -47,4 +47,5 @@ Route::middleware('auth', 'verified')->group(function () {
     Route::get('/cancel', [PurchaseController::class, 'cancel'])->name('stripe.cancel');
 });
 
+Route::get('/stripe/session-status', [PurchaseController::class, 'getSessionStatus']);
 Route::post('/webhook/stripe', [StripeWebhookController::class, 'handleWebhook']);


### PR DESCRIPTION
二重登録対策（送信ボタンをダブルクリックした際の重複登録を防止）
商品が購入済みの状態でstripeの購入ボタンをクリックした場合、重複購入を防止し購入者に売り切れメールを送信
プロフィールが未設定の状態での送信を防止（コメント送信時、 配送先変更時、出品時）

修正
　ダミーデータのaddress（建物名を入れないようにした）
　usersテーブルのemailのユニークキー復元
　購入画面のバリデーションメッセージを取得する際の項目名修正