### PR TITLE
css修正

### DIFF
--- a/src/app/Http/Controllers/ItemController.php
+++ b/src/app/Http/Controllers/ItemController.php
@@ -14,7 +14,7 @@ class ItemController extends Controller
     public function index(Request $request) {
         $parameter = Item::getParameter($request);
 
-        switch ($request['tab']) {
+        switch ($request['page']) {
             case 'suggest':
                 $items = Item::searchSuggestItems();
                 break;

--- a/src/app/Http/Controllers/UserController.php
+++ b/src/app/Http/Controllers/UserController.php
@@ -52,7 +52,7 @@ class UserController extends Controller
     public function getMypage(Request $request) {
         $user = User::find(Auth::id(), ['nickname','image_url']);
 
-        switch ($request['tab']) {
+        switch ($request['page']) {
             case 'sell':
                 $items = Item::getExhibitedItems();
                 break;

--- a/src/app/Http/Requests/AddressRequest.php
+++ b/src/app/Http/Requests/AddressRequest.php
@@ -27,18 +27,16 @@ class AddressRequest extends FormRequest
             'nickname' => ['required'],
             'post_cord' => ['required', 'regex:/^[0-9]{3}-[0-9]{4}\z/'],
             'address' => ['required'],
-            'building' => ['required'],
         ];
     }
 
     public function messages()
     {
         return [
-            'nickname.required' => 'ニックネームを入力してください',
+            'nickname.required' => 'ユーザー名を入力してください',
             'post_cord.required' => '郵便番号を入力してください',
             'post_cord.regex' => '郵便番号は半角数字でハイフン(-)を入れて8文字で入力してください',
             'address.required' => '住所を入力してください',
-            'building.required' => '番地や建物名を入力してください',
         ];
     }
 }

--- a/src/app/Models/Item.php
+++ b/src/app/Models/Item.php
@@ -142,7 +142,7 @@ class Item extends Model
 
     public static function getParameter($request)
     {
-        $parameter = $request->input('tab');
+        $parameter = $request->input('page');
 
         return $parameter;
     }

--- a/src/public/css/form.css
+++ b/src/public/css/form.css
@@ -23,6 +23,8 @@
 
 .form-group__item-label {
     font-weight: bold;
+    align-items: center;
+    gap: 8px;
 }
 
 .form-group__item-input {
@@ -51,4 +53,14 @@
     text-align: center;
     font-size: 14px;
     color: #0073cc;
+}
+
+.form-text__required {
+    display: inline-block;
+    vertical-align: middle;
+    padding: 0 8px;
+    font-size: 12px;
+    background-color: #fd5151;
+    color: #fff;
+    border-radius: 3px;
 }

--- a/src/public/css/sell.css
+++ b/src/public/css/sell.css
@@ -21,16 +21,6 @@
     gap: 8px;
 }
 
-.sell-text__required {
-    display: inline-block;
-    vertical-align: middle;
-    padding: 0 8px;
-    font-size: 12px;
-    background-color: #fd5151;
-    color: #fff;
-    border-radius: 3px;
-}
-
 .sell-detail__group,
 .sell-content__group {
     gap: 20px;

--- a/src/public/js/app.js
+++ b/src/public/js/app.js
@@ -4,10 +4,9 @@ document.addEventListener("DOMContentLoaded", function () {
 
         form.addEventListener("submit", function () {
             button.disabled = true;
-            button.textContent = "登録中...";
+            button.textContent = "処理中...";
         });
     });
-
 
     setTimeout(() => {
         document.querySelectorAll('.flash_success-message, .flash_error-message').forEach(el => {

--- a/src/resources/views/auth/verify_email.blade.php
+++ b/src/resources/views/auth/verify_email.blade.php
@@ -5,6 +5,12 @@
 @endsection
 
 @section('content')
+@if (session('result'))
+    <div class="flash_success-message">
+        {{ session('result') }}
+    </div>
+@endif
+
 <div class="verify-email__container">
     <h2 class="verify-email__header-text">
         登録していただいたメールアドレスに認証メールを送付しました。
@@ -12,7 +18,7 @@
         メール認証を完了してください。
     </h2>
 
-    <a class="verify-email__btn" href="https://{{ Auth::user()->email }}" target="_blank" class="btn">認証はこちらから</a>
+    <a class="verify-email__btn" href="http://localhost:8025" target="_blank">認証はこちらから</a>
 
     <form class="verify-email__form" method="POST" action="{{ route('verification.send') }}">
         @csrf

--- a/src/resources/views/detail.blade.php
+++ b/src/resources/views/detail.blade.php
@@ -80,7 +80,9 @@
                 <div class="item-comment__wrap">
                     <div class="item-comment__user flex">
                         <div class="item-comment__img-wrap user-img__wrap">
+                            @if($user['image_url'])
                             <img class="user-img" src="{{ $user['image_url'] }}" alt="">
+                            @endif
                         </div>
                         <p class="item-comment__name">{{ $user['nickname'] }}</p>
                     </div>

--- a/src/resources/views/index.blade.php
+++ b/src/resources/views/index.blade.php
@@ -15,13 +15,11 @@
 <div class="list-container">
     <div class="list-menu__group border">
         <form class="list-menu__form" action="/" method="GET">
-            @csrf
-            <input type="hidden" name="tab" value="suggest">
+            <input type="hidden" name="page" value="suggest">
             <button class="list-menu__text {{ ($parameter == 'suggest') ? 'selected' : '' }}" type="submit">おすすめ</button>
         </form>
         <form class="list-menu__form" action="/" method="GET">
-            @csrf
-            <input type="hidden" name="tab" value="mylist">
+            <input type="hidden" name="page" value="mylist">
             <button class="list-menu__text {{ ($parameter == 'mylist') ? 'selected' : '' }}" type="submit">マイリスト</button>
         </form>
     </div>

--- a/src/resources/views/layouts/app.blade.php
+++ b/src/resources/views/layouts/app.blade.php
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>coachtechフリマ</title>
     <link rel="stylesheet" href="https://unpkg.com/ress@5.0.2/dist/ress.min.css">
     <link rel="stylesheet" href="{{ asset('css/common.css')}}">
@@ -10,13 +11,21 @@
 </head>
 
 <body>
+    @php
+        $isEmailVerifyPage = request()->is('email/verify');
+    @endphp
     <header class="header">
-        @if (!request()->is('email/verify'))
+        @if (!$isEmailVerifyPage)
         <a class="header-logo" href="/">
             <img class="header-logo__img" src="{{ asset('images/logo.svg') }}" alt="coachtech" width="260px">
         </a>
+        @else
+        <div class="header-logo">
+            <img class="header-logo__img" src="{{ asset('images/logo.svg') }}" alt="coachtech" width="260px">
+        </div>
+        @endif
+
         <form class="search-form" action="/search" method="GET">
-		@csrf
             <input class="search-form__keyword" type="text" placeholder="なにをお探しですか?" value="{{ session('search_keyword', '') }}" name="keyword">
             <button class="search-form__btn" type="submit">
                 <img class="search-form__img" src="{{ asset('images/search.svg') }}" alt="search" width="20px">
@@ -27,23 +36,25 @@
             <ul class="header-nav__list">
                 @auth
                 <li class="header-nav__item">
-                    <form action="/logout" method="POST">
+                    <form action="/logout" method="POST" onsubmit="return confirm('ログアウトしますか？');">
                         @csrf
                         <button class="header-nav__link" type="submit">
                             ログアウト
                         </button>
                     </form>
                 </li>
-                <li class="header-nav__item">
-                    <a class="header-nav__link" href="/mypage">
-                        マイページ
-                    </a>
-                </li>
-                <li class="header-nav__item">
-                    <a class="header-nav__link-sell" href="/sell">
-                        出品
-                    </a>
-                </li>
+                    @if (!$isEmailVerifyPage)
+                    <li class="header-nav__item">
+                        <a class="header-nav__link" href="/mypage">
+                            マイページ
+                        </a>
+                    </li>
+                    <li class="header-nav__item">
+                        <a class="header-nav__link-sell" href="/sell">
+                            出品
+                        </a>
+                    </li>
+                    @endif
                 @else
                 <li class="header-nav__item">
                     <a class="header-nav__link" href="/register">
@@ -58,11 +69,6 @@
                 @endauth
             </ul>
         </nav>
-        @else
-        <div class="header-logo" href="/">
-            <img class="header-logo__img" src="{{ asset('images/logo.svg') }}" alt="coachtech" width="260px">
-        </div>
-        @endif
     </header>
 
     <main class="main">

--- a/src/resources/views/mypage.blade.php
+++ b/src/resources/views/mypage.blade.php
@@ -26,13 +26,11 @@
     <div class="list__inner">
         <div class="list-menu__group border">
             <form class="list-menu__form" action="/mypage" method="GET">
-                @csrf
-                <input type="hidden" name="tab" value="sell">
+                <input type="hidden" name="page" value="sell">
                 <button class="list-menu__text {{ ($parameter == 'sell') ? 'selected' : ''}} " type="submit">出品した商品</button>
             </form>
             <form class="list-menu__form" action="/mypage" method="GET">
-                @csrf
-                <input type="hidden" name="tab" value="buy">
+                <input type="hidden" name="page" value="buy">
                 <button class="list-menu__text {{ ($parameter == 'buy') ? 'selected' : '' }}" type="submit">購入した商品</button>
             </form>
         </div>

--- a/src/resources/views/profile.blade.php
+++ b/src/resources/views/profile.blade.php
@@ -32,7 +32,7 @@
         </div>
 
         <div class="form-group__item">
-            <p class="form-group__item-label">ユーザー名</p>
+            <p class="form-group__item-label flex">ユーザー名<span class="form-text__required">必須</span></p>
             <input class="form-group__item-input" type="text" name="nickname" value="{{ old('nickname') ? old('nickname') : $user['nickname'] }}">
             <div class="error-message">
                 @error('nickname')
@@ -42,7 +42,7 @@
         </div>
 
         <div class="form-group__item">
-            <p class="form-group__item-label">郵便番号</p>
+            <p class="form-group__item-label flex">郵便番号<span class="form-text__required">必須</span></p>
             <input class="form-group__item-input" type="text" name="post_cord" value="{{ old('post_cord') ? old('post_cord') : $user['post_cord'] }}">
             <div class="error-message">
                 @error('post_cord')
@@ -52,7 +52,7 @@
         </div>
 
         <div class="form-group__item">
-            <p class="form-group__item-label">住所</p>
+            <p class="form-group__item-label flex">住所<span class="form-text__required">必須</span></p>
             <input class="form-group__item-input" type="text" name="address" value="{{ old('address') ? old('address') : $user['address'] }}">
             <div class="error-message">
                 @error('address')
@@ -64,11 +64,6 @@
         <div class="form-group__item">
             <p class="form-group__item-label">建物名</p>
             <input class="form-group__item-input" type="text" name="building" value="{{ old('building') ? old('building') : $user['building'] }}">
-            <div class="error-message">
-                @error('building')
-                {{ $message }}
-                @enderror
-            </div>
         </div>
 
         <button class="form-btn btn-margin" type="submit">

--- a/src/resources/views/sell.blade.php
+++ b/src/resources/views/sell.blade.php
@@ -12,7 +12,7 @@
     <form class="sell-form flex" action="/sell" method="POST" enctype="multipart/form-data">
         @csrf
         <div class="sell-img__group">
-            <p class="sell-text flex">商品画像<span class="sell-text__required">必須</span></p>
+            <p class="sell-text flex">商品画像<span class="form-text__required">必須</span></p>
             <div class="sell-img__wrap">
                 <div class="sell-img__inner" id="sellFigure">
                     <img class="sell-img" id="figureImage" src="" alt="">
@@ -30,7 +30,7 @@
         <div class="sell-detail__group flex">
             <h3 class="sell-ttl border">商品の詳細</h3>
             <div class="sell-category__group">
-                <p class="sell-text flex">カテゴリー<span class="sell-text__required">必須</span></p>
+                <p class="sell-text flex">カテゴリー<span class="form-text__required">必須</span></p>
                 <div class="sell-category__wrap flex">
                     @foreach($categories as $category)
                     <input class="sell-category__hidden" type="checkbox" id="{{ $category['name'] }}" name="category[]" value="{{ $category['id'] }}" {{ (is_array(old('category')) && in_array($category['id'], old('category'))) ? 'checked' : '' }}>
@@ -45,7 +45,7 @@
             </div>
 
             <div class="sell-condition_group">
-                <p class="sell-text flex">商品の状態<span class="sell-text__required">必須</span></p>
+                <p class="sell-text flex">商品の状態<span class="form-text__required">必須</span></p>
                 <div class="sell-condition__select-wrap">
                     <select class="sell-condition__select form-group__item-input" name="condition_id" id="">
                         <option value="" selected disabled>選択してください</option>
@@ -65,7 +65,7 @@
         <div class="sell-content__group flex">
             <h3 class="sell-ttl border">商品名と説明</h3>
             <div class="sell-content__inner">
-                <p class="sell-text flex">商品名<span class="sell-text__required">必須</span></p>
+                <p class="sell-text flex">商品名<span class="form-text__required">必須</span></p>
                 <input class="form-group__item-input" type="text" name="name" value="{{ old('name') }}">
                 <div class="error-message">
                     @error('name')
@@ -78,7 +78,7 @@
                 <input class="form-group__item-input" type="text" name="brand_name" value="{{ old('brand_name') }}">
             </div>
             <div class="sell-content__inner">
-                <p class="sell-text flex">商品の説明<span class="sell-text__required">必須</span></p>
+                <p class="sell-text flex">商品の説明<span class="form-text__required">必須</span></p>
                 <textarea class="sell-description__textarea form-group__item-input" name="description" rows="5">{{ old('description') }}</textarea>
                 <div class="error-message">
                     @error('description')
@@ -87,7 +87,7 @@
                 </div>
             </div>
             <div class="sell-content__inner">
-                <p class="sell-text flex">販売価格<span class="sell-text__required">必須</span></p>
+                <p class="sell-text flex">販売価格<span class="form-text__required">必須</span></p>
                 <input class="form-group__item-input" type="text" name="price" placeholder="&yen;" value="{{ old('price') }}">
                 <div class="error-message">
                     @error('price')


### PR DESCRIPTION
トップページのマイリストやマイページの出品した商品を表示する際のパラメーターを『page』に変更
（画面設計と基本設計書で記載が違っていたため統一）

カード決済で既に購入されている商品の購入操作をした場合、決済処理は完了してしまうため、返金処理をする

プロフィール編集画面のbuildingが必須入力ではなくなったため修正、必須入力には『必須』を表示

メール認証画面の『認証はこちらから』ボタンをクリックするとmailhog画面に遷移するよう修正、ヘッダーにログアウト表示

ログアウトボタンをクリックした際に確認ダイアログを表示

