### PR TITLE
brandsテーブル修正

### DIFF
--- a/src/app/Http/Controllers/EmailVerificationNotificationController.php
+++ b/src/app/Http/Controllers/EmailVerificationNotificationController.php
@@ -10,7 +10,9 @@ class EmailVerificationNotificationController extends Controller
     public function resend(Request $request)
     {
         if ($request->user()->hasVerifiedEmail()) {
-            return redirect('/');
+            return $request->wantsJson()
+                        ? new JsonResponse('', 204)
+                        : redirect()->intended(Fortify::redirects('email-verification'));
         }
 
         $request->user()->sendEmailVerificationNotification();

--- a/src/app/Models/Brand.php
+++ b/src/app/Models/Brand.php
@@ -10,7 +10,11 @@ class Brand extends Model
     use HasFactory;
 
     protected $fillable = [
-        'item_id',
         'name',
     ];
+
+    public function items()
+    {
+        return $this->hasMany(Item::class);
+    }
 }

--- a/src/app/Models/Comment.php
+++ b/src/app/Models/Comment.php
@@ -14,4 +14,14 @@ class Comment extends Model
         'item_id',
         'comment',
     ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function item()
+    {
+        return $this->belongsTo(Item::class);
+    }
 }

--- a/src/app/Models/Condition.php
+++ b/src/app/Models/Condition.php
@@ -13,6 +13,11 @@ class Condition extends Model
         'name',
     ];
 
+    public function items() {
+
+        return $this->hasMany(Item::class);
+    }
+
     public static function getConditions()
     {
         $conditions = Condition::all();

--- a/src/app/Models/Favorite.php
+++ b/src/app/Models/Favorite.php
@@ -14,4 +14,14 @@ class Favorite extends Model
         'user_id',
         'item_id',
     ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function item()
+    {
+        return $this->belongsTo(Item::class);
+    }
 }

--- a/src/app/Models/Item.php
+++ b/src/app/Models/Item.php
@@ -15,6 +15,7 @@ class Item extends Model
     protected $fillable = [
         'user_id',
         'condition_id',
+        'brand_id',
         'name',
         'image_url',
         'category',
@@ -35,7 +36,7 @@ class Item extends Model
 
     public function brand()
     {
-        return $this->hasOne(Brand::class);
+        return $this->belongsTo(Brand::class);
     }
 
     public function favorites() {
@@ -43,12 +44,13 @@ class Item extends Model
         return $this->hasMany(Favorite::class);
     }
 
-    public function comments() {
-        return $this->belongsToMany(User::class, 'comments')->withPivot('comment');
+    public function comments()
+    {
+        return $this->hasMany(Comment::class);
     }
 
     public function purchases() {
-        return $this->hasMany(Purchase::class);
+        return $this->hasOne(Purchase::class);
     }
 
     public static function getItems()
@@ -150,7 +152,7 @@ class Item extends Model
     public static function getDetailItem($item_id)
     {
         $item = Item::withCount('favorites', 'comments')
-        ->with('condition', 'brand', 'favorites', 'comments')
+        ->with('condition', 'brand', 'favorites', 'comments.user')
         ->find($item_id);
 
         return $item;
@@ -158,7 +160,7 @@ class Item extends Model
 
     public static function getExhibitedItems()
     {
-        $items = Item::where('user_id', Auth::id())->get();
+        $items = Item::where('user_id', Auth::id())->orderBy('created_at', 'desc')->get();
 
         return $items;
     }

--- a/src/app/Models/Payment.php
+++ b/src/app/Models/Payment.php
@@ -13,6 +13,11 @@ class Payment extends Model
         'way',
     ];
 
+    public function purchase()
+    {
+        return $this->hasMany(Purchase::class);
+    }
+
     public static function getPayments()
     {
         $payments = Payment::all();

--- a/src/app/Models/Purchase.php
+++ b/src/app/Models/Purchase.php
@@ -30,4 +30,9 @@ class Purchase extends Model
         return $this->belongsTo(User::class);
     }
 
+    public function item()
+    {
+        return $this->belongsTo(Item::class);
+    }
+
 }

--- a/src/app/Models/User.php
+++ b/src/app/Models/User.php
@@ -50,6 +50,26 @@ class User extends Authenticatable implements MustVerifyEmail
         'profile_completed' => 'boolean',
     ];
 
+    public function comments()
+    {
+        return $this->hasMany(Comment::class);
+    }
+
+    public function purchases() {
+
+        return $this->hasMany(Purchase::class);
+    }
+
+    public function favorites() {
+
+        return $this->hasMany(Favorite::class);
+    }
+
+    public function items() {
+
+        return $this->hasMany(Item::class);
+    }
+
     public static function getPaymentUser()
     {
         $user = User::select('id', 'post_cord', 'address', 'building')->find(Auth::id());

--- a/src/database/migrations/2025_01_16_144355_create_brands_table.php
+++ b/src/database/migrations/2025_01_16_144355_create_brands_table.php
@@ -15,8 +15,7 @@ class CreateBrandsTable extends Migration
     {
         Schema::create('brands', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('item_id')->constrained()->cascadeOnDelete();
-            $table->string('name');
+            $table->string('name')->unique();
             $table->timestamps();
         });
     }

--- a/src/database/migrations/2025_01_16_144400_create_items_table.php
+++ b/src/database/migrations/2025_01_16_144400_create_items_table.php
@@ -16,12 +16,13 @@ class CreateItemsTable extends Migration
         Schema::create('items', function (Blueprint $table) {
             $table->id();
             $table->foreignId('user_id')->constrained()->cascadeOnDelete();
-            $table->foreignId('condition_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('condition_id')->nullable()->constrained()->nullOnDelete();
+            $table->foreignId('brand_id')->nullable()->constrained()->nullOnDelete();
             $table->string('name');
             $table->text('image_url');
-            $table->string('category');
+            $table->text('category');
             $table->string('description');
-            $table->integer('price');
+            $table->unsignedInteger('price');
             $table->tinyInteger('status')->default(1)->comment('1:出品. 2:購入');
             $table->timestamps();
         });

--- a/src/database/migrations/2025_01_24_144125_create_purchases_table.php
+++ b/src/database/migrations/2025_01_24_144125_create_purchases_table.php
@@ -17,12 +17,12 @@ class CreatePurchasesTable extends Migration
             $table->id();
             $table->foreignId('user_id')->constrained()->cascadeOnDelete();
             $table->foreignId('item_id')->constrained()->cascadeOnDelete();
-            $table->foreignId('payment_id')->comment('1:コンビニ払い 2:カード支払い')->constrained()->cascadeOnDelete();
-            $table->char('post_cord', '8');
+            $table->foreignId('payment_id')->nullable()->constrained('payments')->nullOnDelete();
+            $table->char('post_cord', 8);
             $table->string('address');
-            $table->string('building');
-            $table->string('stripe_session_id');
-            $table->string('payment_status')->default('pending');
+            $table->string('building')->nullable();
+            $table->string('stripe_session_id')->unique();
+            $table->enum('payment_status', ['pending', 'paid', 'canceled'])->default('pending');
             $table->timestamps();
         });
     }

--- a/src/database/seeders/BrandsTableSeeder.php
+++ b/src/database/seeders/BrandsTableSeeder.php
@@ -14,30 +14,10 @@ class BrandsTableSeeder extends Seeder
      */
     public function run()
     {
-        $brands = [
-            [
-                'item_id' => '1',
-                'name' => 'EMPORIO-AMANI',
-            ],
-            [
-                'item_id' => '4',
-                'name' => 'Crockett&Jones',
-            ],
-            [
-                'item_id' => '5',
-                'name' => 'Windows',
-            ],
-            [
-                'item_id' => '6',
-                'name' => 'MAXIM',
-            ],
-            [
-                'item_id' => '7',
-                'name' => 'NINE WEST',
-            ],
-        ];
+        $brands = ['EMPORIO-AMANI', 'Crockett&Jones', 'Windows', 'MAXIM', 'NINE WEST', 'THERMOS', 'ちふれ',];
+
         foreach ($brands as $brand) {
-            DB::table('brands')->insert($brand);
+            DB::table('brands')->insert(['name' => $brand]);
         }
     }
 }

--- a/src/database/seeders/DatabaseSeeder.php
+++ b/src/database/seeders/DatabaseSeeder.php
@@ -16,8 +16,8 @@ class DatabaseSeeder extends Seeder
         \App\Models\User::factory(5)->create();
         $this->call(CategoriesTableSeeder::class);
         $this->call(ConditionsTableSeeder::class);
-        $this->call(ItemsTableSeeder::class);
         $this->call(BrandsTableSeeder::class);
+        $this->call(ItemsTableSeeder::class);
         $this->call(FavoritesTableSeeder::class);
         $this->call(CommentsTableSeeder::class);
         $this->call(PaymentsTableSeeder::class);

--- a/src/database/seeders/ItemsTableSeeder.php
+++ b/src/database/seeders/ItemsTableSeeder.php
@@ -18,6 +18,7 @@ class ItemsTableSeeder extends Seeder
             [
                 'user_id' => mt_rand(1,5),
                 'condition_id' => '1',
+                'brand_id' => '1',
                 'name' => '腕時計',
                 'image_url' => 'https://coachtech-matter.s3.ap-northeast-1.amazonaws.com/image/Armani+Mens+Clock.jpg',
                 'category' => serialize([0=>"1", 1=>"5"]),
@@ -28,6 +29,7 @@ class ItemsTableSeeder extends Seeder
             [
                 'user_id' => mt_rand(1,5),
                 'condition_id' => '2',
+                'brand_id' => null,
                 'name' => 'HDD',
                 'image_url' => 'https://coachtech-matter.s3.ap-northeast-1.amazonaws.com/image/HDD+Hard+Disk.jpg',
                 'category' => serialize([0=>"8"]),
@@ -38,6 +40,7 @@ class ItemsTableSeeder extends Seeder
             [
                 'user_id' => mt_rand(1,5),
                 'condition_id' => '3',
+                'brand_id' => null,
                 'name' => '玉ねぎ3束',
                 'image_url' => 'https://coachtech-matter.s3.ap-northeast-1.amazonaws.com/image/iLoveIMG+d.jpg',
                 'category' => serialize([0=>"10"]),
@@ -48,6 +51,7 @@ class ItemsTableSeeder extends Seeder
             [
                 'user_id' => mt_rand(1,5),
                 'condition_id' => '4',
+                'brand_id' => '2',
                 'name' => '革靴',
                 'image_url' => 'https://coachtech-matter.s3.ap-northeast-1.amazonaws.com/image/Leather+Shoes+Product+Photo.jpg',
                 'category' => serialize([0=>"1", 1=>"5"]),
@@ -58,6 +62,7 @@ class ItemsTableSeeder extends Seeder
             [
                 'user_id' => mt_rand(1,5),
                 'condition_id' => '1',
+                'brand_id' => '3',
                 'name' => 'ノートPC',
                 'image_url' => 'https://coachtech-matter.s3.ap-northeast-1.amazonaws.com/image/Living+Room+Laptop.jpg',
                 'category' => serialize([0=>"8"]),
@@ -68,6 +73,7 @@ class ItemsTableSeeder extends Seeder
             [
                 'user_id' => mt_rand(1,5),
                 'condition_id' => '2',
+                'brand_id' => '4',
                 'name' => 'マイク',
                 'image_url' => 'https://coachtech-matter.s3.ap-northeast-1.amazonaws.com/image/Music+Mic+4632231.jpg',
                 'category' => serialize([0=>"3"]),
@@ -78,6 +84,7 @@ class ItemsTableSeeder extends Seeder
             [
                 'user_id' => mt_rand(1,5),
                 'condition_id' => '3',
+                'brand_id' => '5',
                 'name' => 'ショルダーバッグ',
                 'image_url' => 'https://coachtech-matter.s3.ap-northeast-1.amazonaws.com/image/Purse+fashion+pocket.jpg',
                 'category' => serialize([0=>"4"]),
@@ -88,6 +95,7 @@ class ItemsTableSeeder extends Seeder
             [
                 'user_id' => mt_rand(1,5),
                 'condition_id' => '4',
+                'brand_id' => '6',
                 'name' => 'タンブラー',
                 'image_url' => 'https://coachtech-matter.s3.ap-northeast-1.amazonaws.com/image/Tumbler+souvenir.jpg',
                 'category' => serialize([0=>"10"]),
@@ -98,6 +106,7 @@ class ItemsTableSeeder extends Seeder
             [
                 'user_id' => mt_rand(1,5),
                 'condition_id' => '1',
+                'brand_id' => null,
                 'name' => 'コーヒーミル',
                 'image_url' => 'https://coachtech-matter.s3.ap-northeast-1.amazonaws.com/image/Waitress+with+Coffee+Grinder.jpg',
                 'category' => serialize([0=>"10"]),
@@ -108,6 +117,7 @@ class ItemsTableSeeder extends Seeder
             [
                 'user_id' => mt_rand(1,5),
                 'condition_id' => '2',
+                'brand_id' => '7',
                 'name' => 'メイクセット',
                 'image_url' => 'https://coachtech-matter.s3.ap-northeast-1.amazonaws.com/image/%E5%A4%96%E5%87%BA%E3%83%A1%E3%82%A4%E3%82%AF%E3%82%A2%E3%83%83%E3%83%95%E3%82%9A%E3%82%BB%E3%83%83%E3%83%88.jpg',
                 'category' => serialize([0=>"6"]),

--- a/src/public/css/sell.css
+++ b/src/public/css/sell.css
@@ -82,7 +82,7 @@
 .sell-condition__select-wrap::after {
     position: absolute;
     top: 50%;
-    right: 5%;
+    right: 2%;
     width: 0;
     height: 0;
     border-top: 10px solid #5f5f5f;

--- a/src/public/js/brand_autocomplete.js
+++ b/src/public/js/brand_autocomplete.js
@@ -1,0 +1,35 @@
+document.addEventListener("DOMContentLoaded", function () {
+    const brandInput = document.querySelector("#brand_name");
+    const dataList = document.querySelector("#brand-list");
+
+    function fetchBrands(query = "") {
+        fetch(`/api/brands?query=${encodeURIComponent(query)}`)
+            .then(response => response.json())
+            .then(data => {
+                // console.log("取得したデータ:", data);
+                dataList.innerHTML = ""; // 一度クリア
+
+                // if (data.length === 0) {
+                //     console.warn("⚠️ ブランドが見つかりませんでした");
+                //     return;
+                // }
+
+                data.forEach(brand => {
+                    let option = document.createElement("option");
+                    option.value = brand.name;
+                    dataList.appendChild(option);
+                });
+            })
+            .catch(error => console.error("❌ APIの取得エラー:", error));
+    }
+
+    fetchBrands();
+
+    brandInput.addEventListener("input", function () {
+        if (this.value === "") {
+            fetchBrands(); // 入力が空なら全ブランド表示
+        } else {
+            fetchBrands(this.value);
+        }
+    });
+});

--- a/src/resources/views/detail.blade.php
+++ b/src/resources/views/detail.blade.php
@@ -76,17 +76,17 @@
         <div class="item-comment__group flex">
             <h2 class="item-comment__ttl">コメント ({{ $item['comments_count'] }})</h2>
             <div class="item-comment__inner">
-                @foreach($item->comments as $user)
+                @foreach($item->comments as $comment)
                 <div class="item-comment__wrap">
                     <div class="item-comment__user flex">
                         <div class="item-comment__img-wrap user-img__wrap">
-                            @if($user['image_url'])
-                            <img class="user-img" src="{{ $user['image_url'] }}" alt="">
+                            @if($comment['user']['image_url'])
+                            <img class="user-img" src="{{ $comment['user']['image_url'] }}" alt="">
                             @endif
                         </div>
-                        <p class="item-comment__name">{{ $user['nickname'] }}</p>
+                        <p class="item-comment__name">{{ $comment['user']['nickname'] }}</p>
                     </div>
-                    <p class="item-comment__text">{{ $user->pivot->comment }}</p>
+                    <p class="item-comment__text">{{ $comment['comment'] }}</p>
                 </div>
                 @endforeach
             </div>

--- a/src/resources/views/sell.blade.php
+++ b/src/resources/views/sell.blade.php
@@ -75,7 +75,12 @@
             </div>
             <div class="sell-content__inner">
                 <p class="sell-text bold">ブランド名</p>
-                <input class="form-group__item-input" type="text" name="brand_name" value="{{ old('brand_name') }}">
+                <input class="form-group__item-input sell-brand__input" type="text" name="brand_name" value="{{ old('brand_name') }}" id="brand_name" list="brand-list">
+                <datalist id="brand-list">
+                    @foreach($brands as $brand)
+                        <option value="{{ $brand->name }}">
+                    @endforeach
+                </datalist>
             </div>
             <div class="sell-content__inner">
                 <p class="sell-text flex bold">商品の説明<span class="form-text__required">必須</span></p>
@@ -100,5 +105,6 @@
         <button class="form-btn sell-btn bold" type="submit" onclick="return confirm('商品を出品しますか？');">出品する</button>
     </form>
     <script src="{{ asset('js/preview.js') }}"></script>
+    <script src="{{ asset('js/brand_autocomplete.js') }}"></script>
 </div>
 @endsection

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -8,6 +8,8 @@ use App\Http\Controllers\PurchaseController;
 use App\Http\Controllers\RegisteredUserController;
 use App\Http\Controllers\StripeWebhookController;
 use App\Http\Controllers\EmailVerificationNotificationController;
+use App\Models\Brand;
+use Illuminate\Http\Request;
 
 /*
 |--------------------------------------------------------------------------
@@ -41,6 +43,7 @@ Route::middleware('auth', 'verified')->group(function () {
 
     Route::get('/sell', [UserController::class, 'getSell']);
     Route::post('/sell', [UserController::class, 'postSell']);
+    Route::get('/api/brands', [UserController::class, 'getBrandName']);
 
     Route::get('/purchase/{item_id}', [PurchaseController::class, 'getPurchase']);
     Route::post('/purchase/{item_id}', [PurchaseController::class, 'postPurchase'])->name('stripe.session');


### PR DESCRIPTION
brandsテーブル修正
　ブランド名をユーザーが入力したものをそのまま保存→名前をチェックしなければ新規作成に変更
　itemsテーブルに外部キーbrand_idを追加
　ブランド名を入力する際にオートコンプリート機能を使う

出品した商品の表示を新しい順に修正
migrationとmodelの見直し