### PR TITLE
マイページ関連のテスト&sold表示追加

### DIFF
--- a/src/public/css/detail.css
+++ b/src/public/css/detail.css
@@ -9,6 +9,9 @@
     grid-column: 1/2;
     width: 100%;
     object-fit: cover;
+    position: relative;
+    overflow: hidden;
+    border-radius: 3px;
 }
 
 .item-img {
@@ -175,6 +178,23 @@
 .item-comment__form-btn {
     text-align: center;
     margin-top: 32px;
+}
+
+.sold-out {
+    position: absolute;
+    top: -85px;
+    left: -200px;
+    background-color: #e24a4a;
+    padding: 80px 40px 0 40px;
+    width: 220px;
+    height: 220px;
+    color: #fff;
+    font-size: 28px;
+    transform: rotate(-45deg);
+    transform-origin: top;
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
 }
 
 /* ---modal--- */

--- a/src/resources/views/detail.blade.php
+++ b/src/resources/views/detail.blade.php
@@ -22,6 +22,9 @@
 
 <div class="item-container grid">
     <div class="item-img__wrap">
+        @if($item['status'] == 2)
+        <p class="sold-out bold">Sold</p>
+        @endif
         <img class="item-img" src="{{ $item['image_url'] }}" alt="item">
     </div>
     <div class="item-detail">

--- a/src/resources/views/index.blade.php
+++ b/src/resources/views/index.blade.php
@@ -24,10 +24,12 @@
             <input type="hidden" name="page" value="suggest">
             <button class="list-menu__text bold {{ ($parameter == 'suggest') ? 'selected' : '' }}" type="submit">おすすめ</button>
         </form>
+        @auth
         <form class="list-menu__form" action="/" method="GET">
             <input type="hidden" name="page" value="mylist">
             <button class="list-menu__text bold {{ ($parameter == 'mylist') ? 'selected' : '' }}" type="submit">マイリスト</button>
         </form>
+        @endauth
     </div>
 
     <div class="list-card__group flex">

--- a/src/tests/Feature/ItemDetailTest.php
+++ b/src/tests/Feature/ItemDetailTest.php
@@ -201,6 +201,7 @@ class ItemDetailTest extends TestCase
         $response->assertViewIs('detail');
 
         $response->assertSee('purchased');
+        $response->assertSee('Sold');
         // 購入済みの商品の場合、購入ボタンのクラスにpurchasedを追加し非表示にしている
     }
 
@@ -218,6 +219,7 @@ class ItemDetailTest extends TestCase
         $response->assertViewIs('detail');
 
         $response->assertSee('<a class="item-purchase__btn form-btn bold " href="/purchase/' . $this->item->id . '">購入手続きへ</a>', false);
+        $response->assertDontSee('Sold');
     }
 
     public function ログイン前のユーザーは購入できない()

--- a/src/tests/Feature/ItemDisplayTest.php
+++ b/src/tests/Feature/ItemDisplayTest.php
@@ -20,7 +20,6 @@ class ItemDisplayTest extends TestCase
         $this->seed();
     }
 
-    /** @test */
     public function test_テストデータが正しく作成されたか()
     {
         $this->assertDatabaseCount('users', 5);
@@ -183,6 +182,9 @@ class ItemDisplayTest extends TestCase
         ]);
 
         $response = $this->actingAs($user)->get('/?page=mylist');
+        $response->assertStatus(200)->assertSee('マイリスト');
+
+        // **レスポンスから `items` を取得**
         $items = $response->viewData('items');
         // いいねした商品だけが表示されていることを確認
         $response->assertViewHas('items', function ($items) use ($favoriteItemIds) {
@@ -225,10 +227,9 @@ class ItemDisplayTest extends TestCase
 
     public function test_mylistページでは未認証の場合は何も表示されない()
     {
-        $response = $this->get('/?page=mylist');
+        $response = $this->get('/');
 
-        $items = $response->viewData('items');
-        $response->assertStatus(200)
-        ->assertViewHas('items', fn($items) => count($items) === 0);
+        $response = $this->get('/?page=mylist');
+        $response->assertStatus(200)->assertDontSee('マイリスト');
     }
 }

--- a/src/tests/Feature/MypageTest.php
+++ b/src/tests/Feature/MypageTest.php
@@ -1,0 +1,273 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\Item;
+use App\Models\Purchase;
+use App\Models\Payment;
+use Illuminate\Http\UploadedFile;
+
+class MypageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+    }
+
+    public function test_テストデータが正しく作成されたか()
+    {
+        $this->assertDatabaseCount('users', 5);
+
+        $this->assertDatabaseCount('items', 10);
+        $this->assertDatabaseHas('items', [
+            'name' => '腕時計',
+            'price' => 15000,
+        ]);
+
+        $this->assertDatabaseCount('conditions', 4);
+        $this->assertDatabaseHas('conditions', [
+            'name' => '良好',
+        ]);
+
+        $this->assertDatabaseCount('categories', 14);
+        $this->assertDatabaseHas('categories', [
+            'name' => 'ファッション',
+        ]);
+
+        $this->assertDatabaseCount('brands', 7);
+        $this->assertDatabaseHas('brands', [
+            'name' => 'EMPORIO-AMANI',
+        ]);
+
+        $this->assertDatabaseCount('comments', 5);
+        $this->assertDatabaseHas('comments', [
+            'comment' => 'コメント失礼します。こちらの商品はお値引き可能でしょうか。',
+        ]);
+
+        $this->assertDatabaseCount('favorites', 15);
+    }
+
+    public function test_必要な情報が取得できる_プロフィール画像_ユーザー名()
+    {
+        $user = User::factory()->create([
+            'email_verified_at' => now(),
+            'profile_completed' => true,
+        ]);
+
+        $response = $this->actingAs($user)->get('/mypage');
+
+        $response->assertStatus(200);
+        $response->assertViewIs('mypage');
+
+        $response->assertSee($user->image_url);
+        $response->assertSee($user->nickname);
+    }
+
+    public function test_必要な情報が取得できる_出品した商品一覧()
+    {
+        // 出品商品を持つユーザーを取得
+        $user = User::whereHas('items')->withCount('items')->firstOrFail();
+        $itemsCount = $user->items_count;
+
+        $response = $this->actingAs($user)->get('/mypage?page=sell');
+
+        $response->assertStatus(200)
+        ->assertViewIs('mypage')
+        ->assertViewHas('items', function ($items) use ($itemsCount, $user){
+            return $items->count() === $itemsCount && $items->every(fn ($item) => $item->user_id === $user->id);
+        });
+    }
+
+    public function test_必要な情報が取得できる_購入した商品一覧()
+    {
+        $user = User::factory()->create([
+            'email_verified_at' => now(),
+            'profile_completed' => true,
+        ]);
+        
+        $chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
+        $items = Item::take(3)->get();
+
+        foreach($items as $item) {
+            $randomStr = substr(str_shuffle($chars), 0, 10);
+
+            Purchase::create([
+                'user_id' => $user->id,
+                'item_id' => $item->id,
+                'payment_id' => Payment::first()->id,
+                'post_cord' => $user->post_cord,
+                'address' => $user->address,
+                'building' => $user->building,
+                'stripe_session_id' => $randomStr,
+                'payment_status' => 'paid',
+            ]);
+
+            $item->update([
+                'status' => 2,
+            ]);
+        }
+        
+        $this->assertDatabaseCount('purchases', 3);
+        $this->assertDatabaseHas('purchases', [
+            'user_id' => $user->id,
+        ]);
+
+        $response = $this->actingAs($user)->get('/mypage?page=buy');
+
+        $response->assertStatus(200)
+            ->assertViewIs('mypage')
+            ->assertViewHas('items', function ($items) use ($user){
+                return $items->count() === 3 && $items->every(fn ($item) => $item->purchase->user_id === $user->id);
+            });
+    }
+
+    public function test_初期値として過去設定されていること（プロフィール画像、ユーザー名、郵便番号、住所）()
+    {
+        $user = User::factory()->create([
+            'email_verified_at' => now(),
+            'profile_completed' => true,
+            'image_url' => '/images/test.jpg',
+            'post_cord' => '123-4567',
+            'address' => '東京都新宿区',
+            'building' => 'テストビル101',
+        ]);
+
+        $response = $this->actingAs($user)->get('/mypage/profile');
+        $response->assertStatus(200);
+        $response->assertViewIs('profile');
+
+        $response->assertSee('/images/test.jpg');
+        $response->assertSee('123-4567');
+        $response->assertSee('東京都新宿区');
+        $response->assertSee('テストビル101');
+    }
+
+    public function test_画像の形式が違う場合、バリデーションメッセージが表示される()
+    {
+        $user = User::factory()->create([
+            'email_verified_at' => now(),
+            'profile_completed' => true,
+        ]);
+        $file = UploadedFile::fake()->create('test.pdf', 500, 'application/pdf'); // PDFファイルを作成
+
+        $response = $this->actingAs($user)->get('/mypage/profile');
+        $response->assertStatus(200);
+
+        $response = $this->post('/mypage/profile', [
+            'image_url' => $file,
+            'nickname' => 'test',
+            'post_cord' => '123-4567',
+            'address' => '東京都新宿区',
+            'building' => 'テストビル101',
+        ]);
+
+        $response->assertStatus(302)->assertSessionHasErrors(['image_url' => 'jpegまたはpng形式のファイルを指定してください']);
+    }
+
+    public function test_ユーザー名が未入力の場合、バリデーションメッセージが表示される()
+    {
+        $user = User::factory()->create([
+            'email_verified_at' => now(),
+            'profile_completed' => true,
+        ]);
+
+        $response = $this->actingAs($user)->get('/mypage/profile');
+        $response->assertStatus(200);
+
+        $response = $this->post('/mypage/profile', [
+            'nickname' => '',
+            'post_cord' => '123-4567',
+            'address' => '東京都新宿区',
+            'building' => 'テストビル101',
+        ]);
+
+        $response->assertStatus(302)->assertSessionHasErrors(['nickname' => 'ユーザー名を入力してください']);
+    }
+
+    public function test_郵便番号が未入力の場合、バリデーションメッセージが表示される()
+    {
+        $user = User::factory()->create([
+            'email_verified_at' => now(),
+            'profile_completed' => true,
+        ]);
+
+        $response = $this->actingAs($user)->get('/mypage/profile');
+        $response->assertStatus(200);
+
+        $response = $this->post('/mypage/profile', [
+            'nickname' => 'test',
+            'post_cord' => '',
+            'address' => '東京都新宿区',
+            'building' => 'テストビル101',
+        ]);
+
+        $response->assertStatus(302)->assertSessionHasErrors(['post_cord' => '郵便番号を入力してください']);
+    }
+
+    public function test_郵便番号をハイフンなしで入力の場合、バリデーションメッセージが表示される()
+    {
+        $user = User::factory()->create([
+            'email_verified_at' => now(),
+            'profile_completed' => true,
+        ]);
+
+        $response = $this->actingAs($user)->get('/mypage/profile');
+        $response->assertStatus(200);
+
+        $response = $this->post('/mypage/profile', [
+            'nickname' => 'test',
+            'post_cord' => '1234567',
+            'address' => '東京都新宿区',
+            'building' => 'テストビル101',
+        ]);
+
+        $response->assertStatus(302)->assertSessionHasErrors(['post_cord' => '郵便番号は半角数字でハイフン(-)を入れて8文字で入力してください']);
+    }
+
+    public function test_郵便番号を全角数字で入力の場合、バリデーションメッセージが表示される()
+    {
+        $user = User::factory()->create([
+            'email_verified_at' => now(),
+            'profile_completed' => true,
+        ]);
+
+        $response = $this->actingAs($user)->get('/mypage/profile');
+        $response->assertStatus(200);
+
+        $response = $this->post('/mypage/profile', [
+            'nickname' => 'test',
+            'post_cord' => '１２３−４５６７',
+            'address' => '東京都新宿区',
+            'building' => 'テストビル101',
+        ]);
+
+        $response->assertStatus(302)->assertSessionHasErrors(['post_cord' => '郵便番号は半角数字でハイフン(-)を入れて8文字で入力してください']);
+    }
+
+    public function test_住所が未入力の場合、バリデーションメッセージが表示される()
+    {
+        $user = User::factory()->create([
+            'email_verified_at' => now(),
+            'profile_completed' => true,
+        ]);
+
+        $response = $this->actingAs($user)->get('/mypage/profile');
+        $response->assertStatus(200);
+
+        $response = $this->post('/mypage/profile', [
+            'nickname' => 'test',
+            'post_cord' => '123-4567',
+            'address' => '',
+            'building' => '',
+        ]);
+
+        $response->assertStatus(302)->assertSessionHasErrors(['address' => '住所を入力してください']);
+    }
+}

--- a/src/tests/Feature/PurchaseTest.php
+++ b/src/tests/Feature/PurchaseTest.php
@@ -1,0 +1,229 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\Item;
+use App\Models\Favorite;
+use App\Models\Condition;
+use App\Models\Category;
+use App\Models\Comment;
+use App\Models\Brand;
+use App\Models\Purchase;
+use Mockery;
+use Stripe\Checkout\Session;
+use Stripe\Stripe;
+
+class PurchaseTest extends TestCase
+{
+    use RefreshDatabase;
+    protected $item;
+    protected $user;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+
+        $condition = Condition::create([
+            'name' => '良好',
+        ]);
+
+        Category::create(['name' => 'ファッション']);
+
+        Brand::create(['id' => 1, 'name' => 'テストブランド']);
+
+        $categoryIds = Category::pluck('id')->take(1)->toArray();
+        $this->item = Item::create([
+            'user_id' => $this->user->id,
+            'condition_id' => Condition::first()->id,
+            'brand_id' => Brand::first()->id,
+            'name' => 'テスト商品',
+            'image_url' => '/images/test.jpg',
+            'category' => serialize($categoryIds),
+            'description' => 'これはテスト用の商品です。',
+            'price' => 5000,
+            'status' => 1,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    public function test_テストデータが正しく作成されたか()
+    {
+        $this->assertDatabaseCount('users', 1);
+
+        $this->assertDatabaseCount('items', 1);
+        $this->assertDatabaseHas('items', [
+            'name' => 'テスト商品',
+        ]);
+
+        $this->assertDatabaseCount('conditions', 1);
+        $this->assertDatabaseHas('conditions', [
+            'name' => '良好',
+        ]);
+
+        $this->assertDatabaseCount('categories', 1);
+        $this->assertDatabaseHas('categories', [
+            'name' => 'ファッション',
+        ]);
+
+        $this->assertDatabaseCount('brands', 1);
+        $this->assertDatabaseHas('brands', [
+            'name' => 'テストブランド',
+        ]);
+    }
+
+    public function test_購入ページで必要な情報が表示される()
+    {
+        $user = User::factory()->create([
+            'email_verified_at' => now(),
+            'profile_completed' => true,
+        ]);
+
+        $response = $this->actingAs($user)->get("/purchase/{$this->item->id}");
+        $response->assertStatus(200);
+        $response->assertViewIs('purchase')
+        ->assertViewHas('item')
+        ->assertViewHas('user');
+
+        $response->assertSee($this->item->name);
+        $response->assertSee(number_format($this->item->price));
+        $response->assertSee($user->post_cord);
+        $response->assertSee($user->address);
+        $response->assertSee($user->building);
+    }
+
+    public function test_プロフィールが未設定の状態で配送先変更ボタンをクリックするとプロフィール設定ページにリダイレクトされる()
+    {
+        $user = User::factory()->create([
+            'email_verified_at' => now(),
+            'profile_completed' => false,
+        ]);
+
+        $response = $this->actingAs($user)->get("/purchase/address/{$this->item->id}");
+        $response->assertStatus(200);
+
+        $response->assertRedirect('/mypage/profile');
+        $response->assertSessionHas(['error' => '商品を購入するにはプロフィールを設定してください']);
+    }
+
+    public function test_配送先を未選択場合、バリデーションメッセージが表示される()
+    {
+        $user = User::factory()->create([
+            'email_verified_at' => now(),
+            'profile_completed' => true,
+        ]);
+
+        $response = $this->actingAs($user)->get("/purchase/{$this->item->id}");
+        $response->assertStatus(200);
+
+        $response = $this->post("/purchase/{$this->item->id}", [
+            'payment_id' => '',
+            'post_cord' => '123-4567',
+            'address' => '東京都新宿区',
+            'building' => 'テストビル101',
+        ]);
+
+        $response->assertStatus(302)->assertSessionHasErrors(['payment_id' => '支払い方法を選択してください']);
+    }
+
+    public function test_郵便番号が未入力場合、バリデーションメッセージが表示される()
+    {
+        $user = User::factory()->create([
+            'email_verified_at' => now(),
+            'profile_completed' => false,
+        ]);
+
+        $response = $this->actingAs($user)->get("/purchase/{$this->item->id}");
+        $response->assertStatus(200);
+
+        $response = $this->post("/purchase/{$this->item->id}", [
+            'payment_id' => 1,
+            'post_cord' => '',
+            'address' => '東京都新宿区',
+            'building' => 'テストビル101',
+        ]);
+
+        $response->assertStatus(302)->assertSessionHasErrors(['post_cord' => '郵便番号を設定してください']);
+    }
+
+    public function test_住所が未入力場合、バリデーションメッセージが表示される()
+    {
+        $user = User::factory()->create([
+            'email_verified_at' => now(),
+            'profile_completed' => false,
+        ]);
+
+        $response = $this->actingAs($user)->get("/purchase/{$this->item->id}");
+        $response->assertStatus(200);
+
+        $response = $this->post("/purchase/{$this->item->id}", [
+            'payment_id' => 1,
+            'post_cord' => '123-4567',
+            'address' => '',
+            'building' => 'テストビル101',
+        ]);
+
+        $response->assertStatus(302)->assertSessionHasErrors(['address' => '住所を設定してください']);
+    }
+
+    public function test_正しい情報で購入ボタンをクリックするとstripe決済画面に遷移する()
+    {
+        $user = User::factory()->create([
+            'email_verified_at' => now(),
+            'profile_completed' => true,
+        ]);
+        // Stripe API の `Session::create()` をモック
+        Stripe::setApiKey(env('STRIPE_SECRET'));
+        $mockSession = Mockery::mock('alias:' . Session::class);
+        $mockSession->shouldReceive('create')->once()->andReturn((object) ['url' => 'https://checkout.stripe.com']);
+
+        // 決済リクエストデータ
+        $purchaseData = [
+            'payment_id' => 1,
+            'post_cord' => '123-4567',
+            'address' => '東京都新宿区',
+            'building' => 'テストビル101',
+        ];
+
+        // 購入リクエスト実行
+        $response = $this->actingAs($user)->post("/purchase/{$this->item->id}", $purchaseData);
+
+        // Stripe の決済ページにリダイレクトされるか確認
+        $response->assertRedirect('https://checkout.stripe.com');
+    }
+
+    public function test_送付先住所変更画面にて登録した住所が商品購入画面に反映されている()
+    {
+        $user = User::factory()->create([
+            'email_verified_at' => now(),
+            'profile_completed' => true,
+        ]);
+
+        // 購入画面を開くとデフォルトの情報が表示
+        $response = $this->actingAs($user)->get("/purchase/{$this->item->id}");
+        $response->assertStatus(200);
+
+        $response->assertSee($user->post_cord);
+        $response->assertSee($user->address);
+        $response->assertSee($user->building);
+
+        // 配送先設定
+        $response = $this->post("/purchase/address/{$this->item->id}", [
+            'post_cord' => '987-6543',
+            'address' => '岩手県テスト市テスト町1-1',
+            'building' => '',
+        ]);
+
+        // 購入ページに設定した住所が表示される
+        $response = $this->get("/purchase/address/{$this->item->id}");
+        $response->assertStatus(200);
+
+        $response->assertSee('987-6543');
+        $response->assertSee('岩手県テスト市テスト町1-1');
+    }
+}

--- a/src/tests/Feature/SellTest.php
+++ b/src/tests/Feature/SellTest.php
@@ -1,0 +1,297 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+use App\Models\User;
+use Illuminate\Http\UploadedFile;
+use App\Models\Condition;
+use App\Models\Category;
+use App\Models\Brand;
+use App\Models\Item;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Storage;
+
+class SellTest extends TestCase
+{
+    use RefreshDatabase;
+    protected $brand;
+    protected $condition;
+    protected $categoryIds;
+    protected $file;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed();
+        $this->brand = Brand::first()->name;
+        $this->condition = Condition::first()->id;
+        $this->categoryIds = Category::pluck('id')->take(1)->toArray();
+        $this->file = UploadedFile::fake()->create('test.png', 500, 'image/png'); // pngファイルを作成
+    }
+
+    public function test_テストデータが正しく作成されたか()
+    {
+        $this->assertDatabaseCount('items', 10);
+        $this->assertDatabaseHas('items', [
+            'name' => '腕時計',
+            'price' => 15000,
+        ]);
+
+        $this->assertDatabaseCount('conditions', 4);
+        $this->assertDatabaseHas('conditions', [
+            'name' => '良好',
+        ]);
+
+        $this->assertDatabaseCount('categories', 14);
+        $this->assertDatabaseHas('categories', [
+            'name' => 'ファッション',
+        ]);
+
+        $this->assertDatabaseCount('brands', 7);
+        $this->assertDatabaseHas('brands', [
+            'name' => 'EMPORIO-AMANI',
+        ]);
+    }
+
+    public function test_必須項目を未選択場合、バリデーションメッセージが表示される()
+    {
+        $user = User::factory()->create([
+            'email_verified_at' => now(),
+            'profile_completed' => true,
+        ]);
+
+        $response = $this->actingAs($user)->get('/sell');
+        $response->assertStatus(200);
+
+        $response = $this->post('/sell', [
+            'user_id' => $user->id,
+            'condition_id' => '',
+            'brand_id' => '',
+            'name' => '',
+            'image_url' => '',
+            'category' => '',
+            'description' => '',
+            'price' => '',
+        ]);
+
+        $response->assertStatus(302);
+        $response->assertSessionHasErrors(['image_url' => '商品の画像を選択してください']);
+        $response->assertSessionHasErrors(['category' => '商品のカテゴリーを入力してください']);
+        $response->assertSessionHasErrors(['condition_id' => '商品の状態を入力してください']);
+        $response->assertSessionHasErrors(['name' => '商品名を入力してください']);
+        $response->assertSessionHasErrors(['description' => '商品の説明を入力してください']);
+        $response->assertSessionHasErrors(['price' => '商品の価格を入力してください']);
+    }
+
+    public function test_画像形式が違う場合、バリデーションメッセージが表示される()
+    {
+        $user = User::factory()->create([
+            'email_verified_at' => now(),
+            'profile_completed' => true,
+        ]);
+        $file = UploadedFile::fake()->create('test.pdf', 500, 'application/pdf');
+        // PDFファイルを作成
+
+        $response = $this->actingAs($user)->get('/sell');
+        $response->assertStatus(200);
+
+        $response = $this->post('/sell', [
+            'user_id' => $user->id,
+            'condition_id' => $this->condition,
+            'brand_id' => $this->brand,
+            'name' => 'テスト商品',
+            'image_url' => $file,
+            'category' => $this->categoryIds,
+            'description' => 'テスト説明',
+            'price' => 1000,
+        ]);
+
+        $response->assertStatus(302)->assertSessionHasErrors(['image_url' => 'jpegまたはpng形式のファイルを指定してください']);
+    }
+
+    public function test_商品の説明が256文字以上の場合、バリデーションメッセージが表示される()
+    {
+        $user = User::factory()->create([
+            'email_verified_at' => now(),
+            'profile_completed' => true,
+        ]);
+
+        $response = $this->actingAs($user)->get('/sell');
+        $response->assertStatus(200);
+
+        $response = $this->post('/sell', [
+            'user_id' => $user->id,
+            'condition_id' => $this->condition,
+            'brand_id' => $this->brand,
+            'name' => 'テスト商品',
+            'image_url' => $this->file,
+            'category' => $this->categoryIds,
+            'description' => str_repeat('あ', 256),
+            'price' => 1000,
+        ]);
+
+        $response->assertStatus(302)->assertSessionHasErrors(['description' => '商品の説明は255文字以下で入力してください']);
+    }
+
+    public function test_販売価格が全角数字の場合、バリデーションメッセージが表示される()
+    {
+        $user = User::factory()->create([
+            'email_verified_at' => now(),
+            'profile_completed' => true,
+        ]);
+
+        $response = $this->actingAs($user)->get('/sell');
+        $response->assertStatus(200);
+
+        $response = $this->post('/sell', [
+            'user_id' => $user->id,
+            'condition_id' => $this->condition,
+            'brand_id' => $this->brand,
+            'name' => 'テスト商品',
+            'image_url' => $this->file,
+            'category' => $this->categoryIds,
+            'description' => 'テスト説明',
+            'price' => '１０００',
+        ]);
+
+        $response->assertStatus(302)->assertSessionHasErrors(['price' => '商品の価格は半角数字でカンマ( , )を抜いて入力してください']);
+    }
+
+    public function test_販売価格がカンマ有りで入力した場合、バリデーションメッセージが表示される()
+    {
+        $user = User::factory()->create([
+            'email_verified_at' => now(),
+            'profile_completed' => true,
+        ]);
+
+        $response = $this->actingAs($user)->get('/sell');
+        $response->assertStatus(200);
+
+        $response = $this->post('/sell', [
+            'user_id' => $user->id,
+            'condition_id' => $this->condition,
+            'brand_id' => $this->brand,
+            'name' => 'テスト商品',
+            'image_url' => $this->file,
+            'category' => $this->categoryIds,
+            'description' => 'テスト説明',
+            'price' => '1,000',
+        ]);
+
+        $response->assertStatus(302)->assertSessionHasErrors(['price' => '商品の価格は半角数字でカンマ( , )を抜いて入力してください']);
+    }
+
+    public function test_販売価格をマイナスの数字で入力した場合、バリデーションメッセージが表示される()
+    {
+        $user = User::factory()->create([
+            'email_verified_at' => now(),
+            'profile_completed' => true,
+        ]);
+
+        $response = $this->actingAs($user)->get('/sell');
+        $response->assertStatus(200);
+
+        $response = $this->post('/sell', [
+            'user_id' => $user->id,
+            'condition_id' => $this->condition,
+            'brand_id' => $this->brand,
+            'name' => 'テスト商品',
+            'image_url' => $this->file,
+            'category' => $this->categoryIds,
+            'description' => 'テスト説明',
+            'price' => -1000,
+        ]);
+
+        $response->assertStatus(302)->assertSessionHasErrors(['price' => '商品の価格は0円以上で入力してください']);
+    }
+
+    public function test_商品出品画面にて必要な情報が保存できること()
+    {
+        Storage::fake('public');
+        // 仮想ストレージを使用
+
+        $user = User::factory()->create([
+            'email_verified_at' => now(),
+            'profile_completed' => true,
+        ]);
+        $file = UploadedFile::fake()->create('test.jpeg', 500, 'image/jpeg');
+
+        $response = $this->actingAs($user)->get('/sell');
+        $response->assertStatus(200);
+
+        $response = $this->post('/sell', [
+            'user_id' => $user->id,
+            'condition_id' => $this->condition,
+            'brand_id' => 'テストブランド',
+            'name' => 'テスト商品',
+            'image_url' => $file,
+            'category' => $this->categoryIds,
+            'description' => 'テスト説明',
+            'price' => 1000,
+        ]);
+
+        $response->assertRedirect('/mypage')
+        ->assertSessionHas(['result' => '商品を出品しました']);
+
+        $brandId = Brand::where('name', 'テストブランド')->value('id');
+
+        $this->assertDatabaseHas('items', [
+            'user_id' => $user->id,
+            'condition_id' => $this->condition,
+            'brand_id' => $brandId,
+            'name' => 'テスト商品',
+            'category' => serialize($this->categoryIds),
+            'description' => 'テスト説明',
+            'price' => 1000,
+        ]);
+    }
+
+    public function test_プロフィールが未設定の状態で出品ボタンをクリックするとプロフィール設定ページにリダイレクトされる()
+    {
+        $user = User::factory()->create([
+            'email_verified_at' => now(),
+            'profile_completed' => false,
+        ]);
+
+        $response = $this->actingAs($user)->post('/sell', [
+            'user_id' => $user->id,
+            'condition_id' => $this->condition,
+            'brand_id' => 'テストブランド',
+            'name' => 'テスト商品',
+            'image_url' => $this->file,
+            'category' => $this->categoryIds,
+            'description' => 'テスト説明',
+            'price' => 1000,
+        ]);
+
+        $response->assertRedirect('/mypage/profile');
+        $response->assertSessionHas(['error' => '商品を出品するにはプロフィールを設定してください']);
+    }
+
+    public function test_同じ名前のブランド名は重複して登録されない()
+    {
+        Storage::fake('public');// 仮想ストレージを使用
+        $user = User::factory()->create([
+            'email_verified_at' => now(),
+            'profile_completed' => false,
+        ]);
+        $brandName = Brand::first()->name;
+
+        $response = $this->actingAs($user)->post('/sell', [
+            'user_id' => $user->id,
+            'condition_id' => $this->condition,
+            'brand_id' => $brandName,
+            'name' => 'テスト商品',
+            'image_url' => $this->file,
+            'category' => $this->categoryIds,
+            'description' => 'テスト説明',
+            'price' => 1000,
+        ]);
+
+        $brandCount = Brand::where('name', $brandName)->count();
+        $this->assertEquals(1, $brandCount);
+    }
+}


### PR DESCRIPTION
マイページ関連のテスト（出品商品表示、購入商品表示、プロフィール編集、　出品）

sold表示追加（商品詳細画面でも購入済みのものはSold表示するよう変更、　テスト内容に追加）