### PR TITLE
メッセージ送信機能

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,10 +59,10 @@ services:
       - maildir:/tmp
 
   ngrok:
-    image: ngrok/ngrok
+    image: ngrok/ngrok:latest
     platform: linux/x86_64
     restart: always
-    command: ngrok http nginx:80
+    command: http nginx:80
     depends_on:
       - nginx
     env_file:

--- a/src/app/Http/Controllers/MessageController.php
+++ b/src/app/Http/Controllers/MessageController.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Message;
+use App\Models\User;
+use App\Models\Item;
+use Illuminate\Support\Facades\Auth;
+use App\Http\Requests\MessageRequest;
+use App\Http\Requests\ProfileRequest;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+class MessageController extends Controller
+{
+    public function sendMessage(MessageRequest $messageRequest, ProfileRequest $profileRequest, $transactionId) {
+        try {
+            $user = User::findOrFail(Auth::id());
+            $userId = $user->id;
+
+            $validatedData = array_merge($messageRequest->validated(), $profileRequest->validated());
+
+            $image_url = null;
+            if ($profileRequest->hasFile('image_url')) {
+                try {
+                    $image_url = Item::getImageUrl($profileRequest->file('image_url'));
+                } catch (\Exception $e) {
+                    DB::rollBack();
+                    Log::error("❌ 画像アップロードに失敗しました: " . $e->getMessage());
+                    return redirect()->back()->with('error', '画像のアップロードに失敗しました。再度お試しください。');
+                }
+            }
+
+            DB::beginTransaction();
+
+            try{
+                Message::create([
+                    'transaction_id' => $transactionId,
+                    'sender_id' => $userId,
+                    'message' => $validatedData['message'],
+                    'image_url' => $image_url,
+                ]);
+            } catch (QueryException $e) {
+                DB::rollBack();
+                Log::error("❌ メッセージ登録エラー: " . $e->getMessage());
+                return redirect()->back()->with('error', 'メッセージの登録に失敗しました。再度お試しください。');
+            }
+            
+            DB::commit();
+
+            return redirect()->back()->with('result', 'メッセージを送信しました');
+        } catch (\Exception $e) {
+            DB::rollBack();
+            Log::error("❌ メッセージ投稿エラー: " . $e->getMessage());
+            return redirect()->back()->with('error', 'メッセージの送信に失敗しました。再度お試しください。');
+        }
+    }
+}

--- a/src/app/Http/Requests/ExhibitionRequest.php
+++ b/src/app/Http/Requests/ExhibitionRequest.php
@@ -40,7 +40,7 @@ class ExhibitionRequest extends FormRequest
             'description.required'=>'商品の説明を入力してください',
             'description.max'=>'商品の説明は255文字以下で入力してください',
             'image_url.required'=>'商品の画像を選択してください',
-            'image_url.mimes'=>'jpegまたはpng形式のファイルを指定してください',
+            'image_url.mimes'=>'「.png」または「.jpeg」形式でアップロードしてください',
             'category.required'=>'商品のカテゴリーを入力してください',
             'condition_id.required'=>'商品の状態を入力してください',
             'price.required'=>'商品の価格を入力してください',

--- a/src/app/Http/Requests/MessageRequest.php
+++ b/src/app/Http/Requests/MessageRequest.php
@@ -4,7 +4,7 @@ namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 
-class ProfileRequest extends FormRequest
+class MessageRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -24,14 +24,15 @@ class ProfileRequest extends FormRequest
     public function rules()
     {
         return [
-            'image_url' => ['nullable','mimes:jpeg,png'],
+            'message'=>['required', 'max:400'],
         ];
     }
 
     public function messages()
     {
         return [
-            'image_url.mimes'=>'「.png」または「.jpeg」形式でアップロードしてください',
+            'message.required'=>'本文を入力してください',
+            'message.max'=>'本文は400文字以内で入力してください',
         ];
     }
 }

--- a/src/app/Models/Message.php
+++ b/src/app/Models/Message.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Message extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'transaction_id',
+        'sender_id',
+        'message',
+        'image_url',
+        'read_at',
+    ];
+
+    protected $casts = [
+        'read_at' => 'datetime',
+    ];
+
+    public function transaction()
+    {
+        return $this->belongsTo(Transaction::class);
+    }
+
+    public function sender()
+    {
+        return $this->belongsTo(User::class, 'sender_id');
+    }
+
+    public static function markAsRead($transactionId, $user)
+    {
+        $messages = Message::where('transaction_id', $transactionId)
+        ->where('sender_id', '!=', $user['id'])
+        ->whereNull('read_at')
+        ->update(['read_at' => now()]);
+    }
+}

--- a/src/app/Models/Transaction.php
+++ b/src/app/Models/Transaction.php
@@ -4,6 +4,8 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use App\Models\Message;
+use Illuminate\Support\Facades\DB;
 
 class Transaction extends Model
 {
@@ -31,7 +33,26 @@ class Transaction extends Model
         return $this->belongsTo(User::class, 'buyer_id');
     }
 
-    public static function getTransactionItems($userId)
+    public function sentMessages()
+    {
+        return $this->hasMany(Message::class);
+    }
+
+    public static function getUnreadMessageCount($userId)
+    {
+        $transactionIds = Transaction::where('buyer_id', $userId)
+            ->orWhere('seller_id', $userId)
+            ->pluck('id');
+
+        $unreadCount = Message::whereIn('transaction_id', $transactionIds)
+            ->whereNull('read_at')
+            ->where('sender_id', '!=', $userId)
+            ->count();
+
+        return $unreadCount;
+    }
+
+    public static function getTransactionItemsWithUnreadCount($userId)
     {
         $items = Transaction::where(function ($query) use ($userId) {
             $query->where('buyer_id', $userId)
@@ -41,8 +62,19 @@ class Transaction extends Model
             $query->where('seller_id', $userId)
                 ->where('status', 'chatting');
         })
-        ->with('purchase.item')
+        ->with(['purchase.item', 'sentMessages' => function ($query) use ($userId) {
+            $query->whereNull('read_at')
+                ->where('sender_id', '!=', $userId);
+        }])
+        ->withCount(['sentMessages as latest_message_at' => function ($q) {
+            $q->select(DB::raw('MAX(created_at)'));
+        }])
+        ->orderByDesc('latest_message_at')
         ->get();
+
+        $items->each(function ($item) {
+            $item->unread_count = $item->sentMessages->count();
+        });
 
         return $items;
     }

--- a/src/app/Models/User.php
+++ b/src/app/Models/User.php
@@ -80,6 +80,11 @@ class User extends Authenticatable implements MustVerifyEmail
         return $this->hasMany(Transaction::class, 'seller_id');
     }
 
+    public function sentMessages()
+    {
+        return $this->hasMany(Message::class, 'sender_id');
+    }
+
     public static function getPaymentUser($userId)
     {
         $user = User::select('id', 'post_cord', 'address', 'building')->findOrFail($userId);

--- a/src/database/migrations/2025_04_10_163344_create_messages_table.php
+++ b/src/database/migrations/2025_04_10_163344_create_messages_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateMessagesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('messages', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('transaction_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('sender_id')->constrained('users', 'id')->cascadeOnDelete();
+            $table->text('message');
+            $table->text('image_url')->nullable();
+            $table->timestamp('read_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('messages');
+    }
+}

--- a/src/public/css/transaction.css
+++ b/src/public/css/transaction.css
@@ -1,6 +1,6 @@
 .transaction-container {
     width: 100vw;
-    height: 100vh;
+    height: 100%;
     grid-template-columns: 20% 1fr;
 }
 
@@ -34,6 +34,7 @@
 .transaction-wrap {
     grid-column: 2/3;
     padding: 0 12px;
+    height: 100%;
 }
 
 .transaction-user__img-wrap {
@@ -107,6 +108,13 @@
     font-size: 24px;
 }
 
+.transaction-message__container {
+    width: 100%;
+    height: calc(100vh - 340px);
+    overflow-y: auto;
+    padding-bottom: 68px;
+}
+
 .transaction-message__other-wrap,
 .transaction-message__self-wrap {
     width: 45%;
@@ -136,13 +144,17 @@
 
 .transaction-form {
     position: fixed;
-    bottom: 12px;
+    bottom: 0;
     right: 0;
-    left: 20%;
+    left: 21%;
+    padding: 12px;
+    background-color: #fff;
+}
+
+.transaction-form__group {
     grid-template-columns: 1fr 110px 42px;
     align-items: center;
     gap: 12px;
-    padding: 0 12px;
 }
 
 .transaction-form__img-select {
@@ -161,13 +173,32 @@
     gap: 18px;
     margin-top: 4px;
     margin-right: 8px;
+    align-items: center;
     justify-content: right;
+}
+
+.transaction-message__delete-form {
+    display: flex;
     align-items: center;
 }
 
 .transaction-message__update-btn,
 .transaction-message__delete-btn {
+    display: inline-flex;
     font-size: 12px;
     color: #5f5f5f;
     text-shadow: 1px 2px 3px #dadada;
+}
+
+.transaction-message__chat-img-wrap {
+    max-width: 100%;
+    max-height: 300px;
+    margin-top: 8px;
+}
+
+.transaction-message__chat-img {
+    width: 100%;
+    height: 100%;
+    max-height: 300px;
+    object-fit: contain;
 }

--- a/src/public/js/app.js
+++ b/src/public/js/app.js
@@ -1,11 +1,19 @@
 document.addEventListener("DOMContentLoaded", function () {
-    document.querySelectorAll('.form-group, .item-comment__form, .purchase-form, .sell-form').forEach(form => {
+    document.querySelectorAll('.form-group, .item-comment__form, .purchase-form, .sell-form, .transaction-form').forEach(form => {
         const button = form.querySelector('.form-btn');
+        const iconButton = form.querySelector('.transaction-form__btn');
 
         if (button) {
             form.addEventListener("submit", function () {
                 button.disabled = true;
                 button.textContent = "処理中...";
+            });
+        }
+
+        if (iconButton) {
+            form.addEventListener("submit", function () {
+                iconButton.disabled = true;
+                iconButton.innerHTML = '<span>処理中...</span>';
             });
         }
     });

--- a/src/resources/views/mypage.blade.php
+++ b/src/resources/views/mypage.blade.php
@@ -44,7 +44,11 @@
             </form>
             <form class="list-menu__form" action="/mypage" method="GET">
                 <input type="hidden" name="page" value="transaction">
-                <button class="list-menu__text bold {{ ($parameter == 'transaction') ? 'selected' : '' }}" type="submit">取引中の商品<span class="unread-count__span">2</span></button>
+                <button class="list-menu__text bold {{ ($parameter == 'transaction') ? 'selected' : '' }}" type="submit">取引中の商品
+                    @if($unreadCount > 0)
+                    <span class="unread-count__span">{{ $unreadCount }}</span>
+                    @endif
+                </button>
             </form>
         </div>
 
@@ -67,7 +71,9 @@
             @foreach($items as $item)
             <div class="list-card__item">
                 <div class="list-card__wrap">
-                    <p class="new-message__count flex">10</p>
+                    @if($item['unread_count'] > 0)
+                    <p class="new-message__count flex">{{ $item['unread_count'] }}</p>
+                    @endif
                     <a class="list-card__link" href="/transaction/{{ $item['id'] }}">
                         <img class="list-card__img" src="{{ $item['purchase']['item']['image_url'] }}" alt="item">
                     </a>

--- a/src/resources/views/transaction.blade.php
+++ b/src/resources/views/transaction.blade.php
@@ -39,7 +39,9 @@
                 @endif
             </div>
             <h2 class="transaction-name">{{ $otherUser['nickname'] }}さんとの取引画面</h2>
+            @if($transaction['buyer_id'] == $user['id'])
             <a class="transaction-complete__btn" href="">取引を完了する</a>
+            @endif
         </div>
 
         <div class="transaction-item__wrap flex">
@@ -53,34 +55,23 @@
         </div>
 
         <div class="transaction-message__container">
-            <div class="transaction-message__other-wrap">
-                <div class="transaction-message__content flex">
-                    <div class="transaction-message__img-wrap">
-                        @if($otherUser['image_url'])
-                        <img class="transaction-message__img" src="{{ $otherUser['image_url'] }}" alt="">
-                        @endif
-                    </div>
-                    <p class="transaction-message__name bold">{{ $otherUser['nickname'] }}</p>
-                </div>
-                <div class="error-message">
-                    message
-                </div>
-                <p class="transaction-message__text">メッセージメッセージ</p>
-            </div>
-
+            @foreach($messages as $message)
+            @if($message->sender_id === $user->id)
             <div class="transaction-message__self-wrap">
                 <div class="transaction-message__content flex message-self">
-                    <p class="transaction-message__name bold">{{ $user['nickname'] }}</p>
+                    <p class="transaction-message__name bold">{{ $message['sender']['nickname'] }}</p>
                     <div class="transaction-message__img-wrap">
-                        @if($user['image_url'])
-                        <img class="transaction-message__img" src="{{ $user['image_url'] }}" alt="">
+                        @if($message['sender']['image_url'])
+                        <img class="transaction-message__img" src="{{ $message['sender']['image_url'] }}" alt="">
                         @endif
                     </div>
                 </div>
-                <div class="error-message">
-                    message
+                <p class="transaction-message__text">{{ $message['message'] }}</p>
+                @if($message['image_url'])
+                <div class="transaction-message__chat-img-wrap">
+                    <img class="transaction-message__chat-img" src="{{ $message['image_url'] }}" alt="">
                 </div>
-                <p class="transaction-message__text">メッセージ</p>
+                @endif
                 <div class="transaction-message__form-group flex">
                     <a class="transaction-message__update-btn" href="">編集</a>
                     <form class="transaction-message__delete-form" action="" method="">
@@ -89,16 +80,46 @@
                     </form>
                 </div>
             </div>
+            @else
+            <div class="transaction-message__other-wrap">
+                <div class="transaction-message__content flex">
+                    <div class="transaction-message__img-wrap">
+                        @if($message['sender']['image_url'])
+                        <img class="transaction-message__img" src="{{ $message['sender']['image_url'] }}" alt="">
+                        @endif
+                    </div>
+                    <p class="transaction-message__name bold">{{ $message['sender']['nickname'] }}</p>
+                </div>
+                <p class="transaction-message__text">{{ $message['message'] }}</p>
+                @if($message['image_url'])
+                <div class="transaction-message__chat-img-wrap">
+                    <img class="transaction-message__chat-img" src="{{ $message['image_url'] }}" alt="">
+                </div>
+                @endif
+            </div>
+            @endif
+            @endforeach
         </div>
 
-        <form class="transaction-form grid" method="" action="">
+        <form class="transaction-form grid" method="POST" action="/transaction/{{ $transaction['id'] }}" enctype="multipart/form-data">
             @csrf
-            <textarea class="transaction-form__message-input" type="text" name="" rows="1" placeholder="取引メッセージを入力してください"></textarea>
-            <label class="transaction-form__img-select bold" for="upload">画像を追加</label>
-            <input class="transaction-form__img-hidden" type="file" id="upload" name="" accept="image/png, image/jpeg">
-            <button class="transaction-form__btn" type="submit"><img class="transaction-form__btn-img" src="{{ asset('images/sendbutton.svg') }}" alt="コメント" width="54px"></button>
+            <div class="error-message">
+                @error('message')
+                {{ $message }}
+                @enderror
+            </div>
+            <div class="error-message">
+                @error('image_url')
+                {{ $message }}
+                @enderror
+            </div>
+            <div class="transaction-form__group grid">
+                <textarea class="transaction-form__message-input" type="text" name="message" rows="1" placeholder="取引メッセージを入力してください">{{ old('message') }}</textarea>
+                <label class="transaction-form__img-select bold" for="upload">画像を追加</label>
+                <input class="transaction-form__img-hidden" type="file" id="upload" name="image_url" accept="image/png, image/jpeg">
+                <button class="transaction-form__btn" type="submit"><img class="transaction-form__btn-img" src="{{ asset('images/sendbutton.svg') }}" alt="コメント" width="54px"></button>
+            </div>
         </form>
     </div>
 </div>
-
 @endsection

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\PurchaseController;
 use App\Http\Controllers\RegisteredUserController;
 use App\Http\Controllers\StripeWebhookController;
 use App\Http\Controllers\EmailVerificationNotificationController;
+use App\Http\Controllers\MessageController;
 
 /*
 |--------------------------------------------------------------------------
@@ -52,7 +53,8 @@ Route::middleware('auth', 'verified')->group(function () {
     Route::get('/success', [PurchaseController::class, 'success'])->name('stripe.success');
     Route::get('/cancel', [PurchaseController::class, 'cancel'])->name('stripe.cancel');
 
-    Route::get('/transaction/{transaction}', [UserController::class, 'transaction']);
+    Route::get('/transaction/{transaction}', [UserController::class, 'getTransaction']);
+    Route::post('/transaction/{transaction}', [MessageController::class, 'sendMessage']);
 });
 
 Route::get('/stripe/session-status', [PurchaseController::class, 'getSessionStatus']);

--- a/src/tests/Feature/MypageTest.php
+++ b/src/tests/Feature/MypageTest.php
@@ -189,7 +189,7 @@ class MypageTest extends TestCase
             'building' => 'テストビル101',
         ]);
 
-        $response->assertStatus(302)->assertSessionHasErrors(['image_url' => 'jpegまたはpng形式のファイルを指定してください']);
+        $response->assertStatus(302)->assertSessionHasErrors(['image_url' => '「.png」または「.jpeg」形式でアップロードしてください']);
     }
 
     public function test_ユーザー名が未入力の場合、バリデーションメッセージが表示される()

--- a/src/tests/Feature/SellTest.php
+++ b/src/tests/Feature/SellTest.php
@@ -101,7 +101,7 @@ class SellTest extends TestCase
             'price' => 1000,
         ]);
 
-        $response->assertStatus(302)->assertSessionHasErrors(['image_url' => 'jpegまたはpng形式のファイルを指定してください']);
+        $response->assertStatus(302)->assertSessionHasErrors(['image_url' => '「.png」または「.jpeg」形式でアップロードしてください']);
     }
 
     public function test_商品の説明が256文字以上の場合、バリデーションメッセージが表示される()


### PR DESCRIPTION
マイページに未読メッセージ件数表示
取引中の商品に商品ごとの未読メッセージ件数表示、新規メッセージが来た順に並び替え
取引画面でメッセージ送信（MessageRequestが本文用、　ProfileRequestが画像用）、ダブルクリック対策、画像がある場合表示、メッセージ部分のみスクロール、購入者に取引完了ボタン表示