### PR TITLE
メッセージ編集機能

### DIFF
--- a/src/app/Http/Controllers/MessageController.php
+++ b/src/app/Http/Controllers/MessageController.php
@@ -8,9 +8,11 @@ use App\Models\User;
 use App\Models\Item;
 use Illuminate\Support\Facades\Auth;
 use App\Http\Requests\MessageRequest;
+use App\Http\Requests\EditMessageRequest;
 use App\Http\Requests\ProfileRequest;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use Exception;
 
 class MessageController extends Controller
 {
@@ -53,6 +55,24 @@ class MessageController extends Controller
         } catch (\Exception $e) {
             DB::rollBack();
             Log::error("❌ メッセージ投稿エラー: " . $e->getMessage());
+            return redirect()->back()->with('error', 'メッセージの送信に失敗しました。再度お試しください。');
+        }
+    }
+
+    public function update(EditMessageRequest $request, $messageId)
+    {
+        try {
+            $message = Message::findOrFail($messageId);
+            DB::beginTransaction();
+            $message->update([
+                'message' => $request->message_send,
+            ]);
+            DB::commit();
+
+            return redirect()->back()->with('message_updated', true)->with('result', 'メッセージを更新しました');
+        } catch (\Exception $e) {
+            DB::rollBack();
+            Log::error("❌ メッセージ更新エラー: " . $e->getMessage());
             return redirect()->back()->with('error', 'メッセージの送信に失敗しました。再度お試しください。');
         }
     }

--- a/src/app/Http/Requests/EditMessageRequest.php
+++ b/src/app/Http/Requests/EditMessageRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class EditMessageRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'message_send'=>['required', 'max:400'],
+        ];
+    }
+
+    public function messages()
+    {
+        return [
+            'message_send.required'=>'本文を入力してください',
+            'message_send.max'=>'本文は400文字以内で入力してください',
+        ];
+    }
+}

--- a/src/public/css/common.css
+++ b/src/public/css/common.css
@@ -29,7 +29,8 @@ a {
     font-weight: bold;
 }
 
-.error-message {
+.error-message,
+.edit-error-message {
     color: #e24a4a;
 }
 

--- a/src/public/css/form.css
+++ b/src/public/css/form.css
@@ -27,7 +27,8 @@
 }
 
 .form-group__item-input,
-.transaction-form__message-input {
+.transaction-form__message-input,
+.transaction-edit-form__message-input {
     border: 1px solid #5F5F5F;
     width: 100%;
     border-radius: 3px;

--- a/src/public/css/transaction.css
+++ b/src/public/css/transaction.css
@@ -110,7 +110,7 @@
 
 .transaction-message__container {
     width: 100%;
-    height: calc(100vh - 340px);
+    height: calc(100vh - 334px);
     overflow-y: auto;
     padding-bottom: 68px;
 }
@@ -169,7 +169,8 @@
     margin-top: -14px;
 }
 
-.transaction-message__form-group {
+.transaction-message__form-group,
+.transaction-edit-form__btn-group {
     gap: 18px;
     margin-top: 4px;
     margin-right: 8px;
@@ -183,7 +184,9 @@
 }
 
 .transaction-message__update-btn,
-.transaction-message__delete-btn {
+.transaction-message__delete-btn,
+.transaction-edit__btn,
+.transaction-cancel-edit__btn {
     display: inline-flex;
     font-size: 12px;
     color: #5f5f5f;
@@ -201,4 +204,20 @@
     height: 100%;
     max-height: 300px;
     object-fit: contain;
+}
+
+.transaction-edit-form {
+    width: 100%;
+    margin-top: 8px;
+}
+
+.transaction-edit-form__message-input {
+    text-align: center;
+}
+
+@media screen and (max-width: 959px) {
+
+    .transaction-message__container {
+        height: calc(100vh - 374px);
+    }
 }

--- a/src/public/js/app.js
+++ b/src/public/js/app.js
@@ -1,7 +1,8 @@
 document.addEventListener("DOMContentLoaded", function () {
-    document.querySelectorAll('.form-group, .item-comment__form, .purchase-form, .sell-form, .transaction-form').forEach(form => {
+    document.querySelectorAll('.form-group, .item-comment__form, .purchase-form, .sell-form, .transaction-form, .transaction-edit-form').forEach(form => {
         const button = form.querySelector('.form-btn');
         const iconButton = form.querySelector('.transaction-form__btn');
+        const editButton = form.querySelector('.transaction-edit__btn');
 
         if (button) {
             form.addEventListener("submit", function () {
@@ -14,6 +15,13 @@ document.addEventListener("DOMContentLoaded", function () {
             form.addEventListener("submit", function () {
                 iconButton.disabled = true;
                 iconButton.innerHTML = '<span>処理中...</span>';
+            });
+        }
+
+        if (editButton) {
+            form.addEventListener("submit", function () {
+                editButton.disabled = true;
+                editButton.textContent = "更新中...";
             });
         }
     });

--- a/src/public/js/message_edit.js
+++ b/src/public/js/message_edit.js
@@ -1,0 +1,68 @@
+document.addEventListener("DOMContentLoaded", function () {
+    const updateButtons = document.querySelectorAll('.transaction-message__update-btn');
+    const cancelButtons = document.querySelectorAll('.transaction-cancel-edit__btn');
+    const editingId = sessionStorage.getItem('editing_message_id');
+
+    // 対象メッセージの各要素をまとめて取得
+    function getMessageElements(wrapper) {
+        return {
+            wrapper,
+            messageText: wrapper.querySelector('.transaction-message__text'),
+            messageForm: wrapper.querySelector('.transaction-message__form-group'),
+            editForm: wrapper.querySelector('.transaction-edit-form'),
+        };
+    }
+
+    // 編集モードに切り替える
+    function showEditForm(elements) {
+        elements.messageText.style.display = 'none';
+        elements.messageForm.style.display = 'none';
+        elements.editForm.style.display = 'block';
+    }
+
+    // 通常表示に戻す
+    function hideEditForm(elements) {
+        elements.messageText.style.display = 'block';
+        elements.messageForm.style.display = 'flex';
+        elements.editForm.style.display = 'none';
+    }
+
+    // ページロード時：編集状態を復元 or 完了後に閉じる
+    if (editingId) {
+        const wrapper = document.querySelector(`.transaction-message__self-wrap[data-message-id="${editingId}"]`);
+        if (wrapper) {
+            const elements = getMessageElements(wrapper);
+            const updateStatus = document.getElementById('message-update-status');
+            if (updateStatus && updateStatus.dataset.updated === 'true') {
+                hideEditForm(elements);
+                sessionStorage.removeItem('editing_message_id');
+            } else {
+                showEditForm(elements);
+            }
+        }
+    }
+
+    // 編集ボタンが押された時
+    updateButtons.forEach(button => {
+        button.addEventListener('click', function (e) {
+            e.preventDefault();
+            const wrapper = button.closest('.transaction-message__self-wrap');
+            const messageId = wrapper.dataset.messageId;
+            const elements = getMessageElements(wrapper);
+
+            sessionStorage.setItem('editing_message_id', messageId);
+            showEditForm(elements);
+        });
+    });
+
+    // キャンセルボタンが押された時
+    cancelButtons.forEach(button => {
+        button.addEventListener('click', function () {
+            const wrapper = button.closest('.transaction-message__self-wrap');
+            const elements = getMessageElements(wrapper);
+
+            sessionStorage.removeItem('editing_message_id');
+            hideEditForm(elements);
+        });
+    });
+});

--- a/src/resources/views/transaction.blade.php
+++ b/src/resources/views/transaction.blade.php
@@ -57,7 +57,7 @@
         <div class="transaction-message__container">
             @foreach($messages as $message)
             @if($message->sender_id === $user->id)
-            <div class="transaction-message__self-wrap">
+            <div class="transaction-message__self-wrap" data-message-id="{{ $message['id'] }}">
                 <div class="transaction-message__content flex message-self">
                     <p class="transaction-message__name bold">{{ $message['sender']['nickname'] }}</p>
                     <div class="transaction-message__img-wrap">
@@ -73,12 +73,26 @@
                 </div>
                 @endif
                 <div class="transaction-message__form-group flex">
-                    <a class="transaction-message__update-btn" href="">編集</a>
+                    <a class="transaction-message__update-btn" href="#">編集</a>
                     <form class="transaction-message__delete-form" action="" method="">
                         @csrf
                         <button class="transaction-message__delete-btn">削除</button>
                     </form>
                 </div>
+                <form class="transaction-edit-form" action="/message/{{ $message['id'] }}" method="POST" style="display: none;">
+                    @csrf
+                    @method('PUT')
+                    <div class="edit-error-message">
+                        @error('message_send')
+                        {{ $message }}
+                        @enderror
+                    </div>
+                    <textarea class="transaction-edit-form__message-input" name="message_send" rows="1">{{ old('message') ? old('message') : $message['message'] }}</textarea>
+                    <div class="transaction-edit-form__btn-group flex">
+                        <button class="transaction-edit__btn" type="submit">更新</button>
+                        <button class="transaction-cancel-edit__btn" type="button">キャンセル</button>
+                    </div>
+                </form>
             </div>
             @else
             <div class="transaction-message__other-wrap">
@@ -105,7 +119,7 @@
             @csrf
             <div class="error-message">
                 @error('message')
-                {{ $message }}
+                    {{ $message }}
                 @enderror
             </div>
             <div class="error-message">
@@ -122,6 +136,12 @@
         </form>
     </div>
 </div>
+
+@if(session('message_updated'))
+    <div id="message-update-status" data-updated="true"></div>
+@endif
+
+<script src="{{ asset('js/message_edit.js') }}"></script>
 <script>
     document.addEventListener("DOMContentLoaded", function () {
         const textarea = document.querySelector('.transaction-form__message-input');

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -55,6 +55,8 @@ Route::middleware('auth', 'verified')->group(function () {
 
     Route::get('/transaction/{transaction}', [UserController::class, 'getTransaction']);
     Route::post('/transaction/{transaction}', [MessageController::class, 'sendMessage']);
+
+    Route::put('/message/{message}', [MessageController::class, 'update']);
 });
 
 Route::get('/stripe/session-status', [PurchaseController::class, 'getSessionStatus']);


### PR DESCRIPTION
編集ボタンクリックでインライン編集に切り替え
編集用のFormRequestを作成し、送信用のエラーメッセージが一緒に表示されないようにした
更新ボタンで情報更新、キャンセルボタンでインライン編集を閉じる
更新ボタンのダブルクリック対策