### PR TITLE
メッセージ画像プレビュー機能

### DIFF
--- a/src/app/Http/Controllers/UserController.php
+++ b/src/app/Http/Controllers/UserController.php
@@ -214,7 +214,7 @@ class UserController extends Controller
 
         $messages = Message::withTrashed()
         ->where('transaction_id', $transactionId)
-        ->with('sender')
+        ->with('sender', 'image')
         ->orderBy('created_at', 'asc')
         ->get();
 

--- a/src/app/Models/Image.php
+++ b/src/app/Models/Image.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Image extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'message_id',
+        'image_url',
+    ];
+
+    public function message()
+    {
+        return $this->belongsTo(Message::class);
+    }
+}

--- a/src/app/Models/Message.php
+++ b/src/app/Models/Message.php
@@ -14,7 +14,6 @@ class Message extends Model
         'transaction_id',
         'sender_id',
         'message',
-        'image_url',
         'read_at',
     ];
 
@@ -30,6 +29,11 @@ class Message extends Model
     public function sender()
     {
         return $this->belongsTo(User::class, 'sender_id');
+    }
+
+    public function image()
+    {
+        return $this->hasOne(Image::class);
     }
 
     public static function markAsRead($transactionId, $user)

--- a/src/database/migrations/2025_04_10_163344_create_messages_table.php
+++ b/src/database/migrations/2025_04_10_163344_create_messages_table.php
@@ -18,7 +18,6 @@ class CreateMessagesTable extends Migration
             $table->foreignId('transaction_id')->constrained()->cascadeOnDelete();
             $table->foreignId('sender_id')->constrained('users', 'id')->cascadeOnDelete();
             $table->text('message');
-            $table->text('image_url')->nullable();
             $table->timestamp('read_at')->nullable();
             $table->softDeletes();
             $table->timestamps();

--- a/src/database/migrations/2025_04_12_092758_create_images_table.php
+++ b/src/database/migrations/2025_04_12_092758_create_images_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateImagesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('images', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('message_id')->constrained()->cascadeOnDelete();
+            $table->text('image_url');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('images');
+    }
+}

--- a/src/public/css/transaction.css
+++ b/src/public/css/transaction.css
@@ -112,7 +112,7 @@
     width: 100%;
     height: calc(100vh - 334px);
     overflow-y: auto;
-    padding-bottom: 68px;
+    padding-bottom: 84px;
 }
 
 .transaction-message__other-wrap,

--- a/src/public/js/message_image_preview.js
+++ b/src/public/js/message_image_preview.js
@@ -1,0 +1,29 @@
+document.addEventListener("DOMContentLoaded", function () {
+    const imageInput = document.getElementById("imageInput");
+    const imageSelectBtn = document.getElementById("imageSelectBtn");
+    const imagePreviewContainer = document.getElementById("imagePreviewContainer");
+
+    imageInput.addEventListener("change", () => {
+        const file = imageInput.files[0];
+        if (file && file.type.startsWith("image/")) {
+            const reader = new FileReader();
+            reader.onload = function (e) {
+                imagePreviewContainer.innerHTML = `
+                    <div style="position: relative; display: inline-block;">
+                        <img src="${e.target.result}" alt="プレビュー画像" style="max-width: 100px; max-height: 100px; border: 1px solid #ccc; margin-top: 10px;">
+                        <button type="button" id="removeImageBtn" style="position: absolute; top: 4px; right: -4px; background: #fff; color:rgb(76, 76, 76); border: 2px solid rgb(76, 76, 76); border-radius: 50%; width: 24px; height: 24px; cursor: pointer;display: flex; align-items: center; justify-content: center; font-size: 16px; line-height: 1;">×</button>
+                    </div>
+                `;
+
+                // 削除ボタンのイベントを追加
+                document.getElementById("removeImageBtn").addEventListener("click", function () {
+                    imagePreviewContainer.innerHTML = "";
+                    imageInput.value = ""; // ファイル選択もリセット
+                });
+            };
+            reader.readAsDataURL(file);
+        } else {
+            imagePreviewContainer.innerHTML = "";
+        }
+    });
+});

--- a/src/resources/views/transaction.blade.php
+++ b/src/resources/views/transaction.blade.php
@@ -73,23 +73,6 @@
                 <p class="transaction-message__text">{{ $message['message'] }}</p>
                 @endif
 
-                @if($message['image_url'] && !$message->deleted_at)
-                <div class="transaction-message__chat-img-wrap">
-                    <img class="transaction-message__chat-img" src="{{ $message['image_url'] }}" alt="">
-                </div>
-                @endif
-
-                @if (!$message->deleted_at)
-                <div class="transaction-message__form-group flex">
-                    <a class="transaction-message__update-btn" href="#">編集</a>
-                    <form class="transaction-message__delete-form" action="/message/{{ $message['id'] }}" method="POST">
-                        @csrf
-                        @method('DELETE')
-                        <button class="transaction-message__delete-btn" onclick="return confirm('「{{ $message['message']}}」\nこのメッセージを削除します。よろしいですか？');">削除</button>
-                    </form>
-                </div>
-                @endif
-
                 <form class="transaction-edit-form" action="/message/{{ $message['id'] }}" method="POST" style="display: none;">
                     @csrf
                     @method('PUT')
@@ -104,6 +87,23 @@
                         <button class="transaction-cancel-edit__btn" type="button">キャンセル</button>
                     </div>
                 </form>
+
+                @if(isset($message['image']) && $message['image']['image_url'] && !$message->deleted_at)
+                <div class="transaction-message__chat-img-wrap">
+                    <img class="transaction-message__chat-img" src="{{ $message['image']['image_url'] }}" alt="">
+                </div>
+                @endif
+
+                @if (!$message->deleted_at)
+                <div class="transaction-message__form-group flex">
+                    <a class="transaction-message__update-btn" href="#">編集</a>
+                    <form class="transaction-message__delete-form" action="/message/{{ $message['id'] }}" method="POST">
+                        @csrf
+                        @method('DELETE')
+                        <button class="transaction-message__delete-btn" onclick="return confirm('「{{ $message['message']}}」\nこのメッセージを削除します。よろしいですか？');">削除</button>
+                    </form>
+                </div>
+                @endif
             </div>
             @else
             <div class="transaction-message__other-wrap">
@@ -122,9 +122,9 @@
                 <p class="transaction-message__text">{{ $message['message'] }}</p>
                 @endif
 
-                @if($message['image_url'] && !$message->deleted_at)
+                @if(isset($message['image']) && $message['image']['image_url'] && !$message->deleted_at)
                 <div class="transaction-message__chat-img-wrap">
-                    <img class="transaction-message__chat-img" src="{{ $message['image_url'] }}" alt="">
+                    <img class="transaction-message__chat-img" src="{{ $message['image']['image_url'] }}" alt="">
                 </div>
                 @endif
             </div>
@@ -144,11 +144,12 @@
                 {{ $message }}
                 @enderror
             </div>
+            <div id="imagePreviewContainer" style="margin-top: 10px;"></div>
             <div class="transaction-form__group grid">
                 <textarea class="transaction-form__message-input" type="text" name="message" rows="1" placeholder="取引メッセージを入力してください">{{ old('message') }}</textarea>
-                <label class="transaction-form__img-select bold" for="upload">画像を追加</label>
-                <input class="transaction-form__img-hidden" type="file" id="upload" name="image_url" accept="image/png, image/jpeg">
-                <button class="transaction-form__btn" type="submit"><img class="transaction-form__btn-img" src="{{ asset('images/sendbutton.svg') }}" alt="コメント" width="54px"></button>
+                <label class="transaction-form__img-select bold" for="imageInput">画像を追加</label>
+                <input class="transaction-form__img-hidden" type="file" id="imageInput" name="image_url" accept="image/png, image/jpeg">
+                <button class="transaction-form__btn" type="submit" id="imageSelectBtn"><img class="transaction-form__btn-img" src="{{ asset('images/sendbutton.svg') }}" alt="コメント" width="54px"></button>
             </div>
         </form>
     </div>
@@ -158,6 +159,7 @@
     <div id="message-update-status" data-updated="true"></div>
 @endif
 
+<script src="{{ asset('js/message_image_preview.js') }}"></script>
 <script src="{{ asset('js/message_edit.js') }}"></script>
 <script>
     document.addEventListener("DOMContentLoaded", function () {


### PR DESCRIPTION
メッセージに画像をつけて送信する場合に画像プレビューを表示、プレビューに表示される×ボタンで選択解除
messagesテーブルにnullableで画像を保存していたが、imagesテーブルを作成し画像がある場合のみ保存するよう変更

画像がある場合にインライン編集を開いた際、画像と並びが逆転してしまっていたため修正